### PR TITLE
Phase 11: Workbench UI and temporal editing

### DIFF
--- a/src/data/models.ts
+++ b/src/data/models.ts
@@ -40,8 +40,8 @@ export interface SectionMap {
   name: string;
   /** Start measure (1-based index) */
   startMeasure: number;
-  /** End measure (1-based index) */
-  endMeasure: number;
+  /** Length of the section in measures. End measure is calculated as: startMeasure + lengthInMeasures - 1 */
+  lengthInMeasures: number;
   /** The instrument configuration active during this section */
   instrumentConfig: InstrumentConfig;
 }

--- a/src/utils/gridPatternToPerformance.ts
+++ b/src/utils/gridPatternToPerformance.ts
@@ -1,5 +1,6 @@
 import { GridPattern } from '../types/gridPattern';
-import { InstrumentConfig, Performance, NoteEvent } from '../types/performance';
+import { Performance, NoteEvent } from '../types/performance';
+import { InstrumentConfig } from '../data/models';
 import { GridMapService } from '../engine/gridMapService';
 
 /**
@@ -35,12 +36,10 @@ export const gridPatternToPerformance = (
         if (stepGrid[row][col]) {
           const noteNumber = GridMapService.getNoteForPosition(row, col, config);
           
+          // W5: NoteEvent simplified - no duration field
           events.push({
             noteNumber,
             startTime,
-            duration: stepDuration, // Default duration is one step
-            velocity: 100, // Default velocity
-            channel: 1
           });
         }
       }
@@ -54,6 +53,66 @@ export const gridPatternToPerformance = (
     events,
     tempo,
     name: 'Generated Performance'
+  };
+};
+
+/**
+ * W5: Converts a Performance object (MIDI events) into a GridPattern (step sequencer data).
+ * Uses the active InstrumentConfig to map notes to grid positions.
+ * 
+ * @param performance The source performance with note events
+ * @param config The instrument configuration for note mapping
+ * @param tempo The project tempo in BPM
+ * @param minSteps Minimum number of steps in the pattern (default: 64)
+ * @returns A GridPattern object containing the step sequencer data
+ */
+export const performanceToGridPattern = (
+  performance: Performance,
+  config: InstrumentConfig,
+  tempo: number,
+  minSteps: number = 64
+): GridPattern => {
+  // Calculate duration of a 16th note in seconds
+  const stepDuration = (60 / tempo) / 4;
+  
+  // Calculate required pattern length from latest event
+  const latestEvent = performance.events.length > 0
+    ? performance.events.reduce((latest, event) => 
+        event.startTime > latest.startTime ? event : latest
+      )
+    : null;
+  
+  const maxStep = latestEvent
+    ? Math.ceil(latestEvent.startTime / stepDuration)
+    : 0;
+  
+  const patternLength = Math.max(minSteps, Math.ceil(maxStep / 16) * 16); // Round up to nearest measure
+  
+  // Initialize empty pattern
+  const steps: boolean[][][] = [];
+  for (let stepIndex = 0; stepIndex < patternLength; stepIndex++) {
+    const stepGrid: boolean[][] = [];
+    for (let row = 0; row < 8; row++) {
+      stepGrid[row] = new Array(8).fill(false);
+    }
+    steps.push(stepGrid);
+  }
+  
+  // Map each event to a grid position and step
+  performance.events.forEach(event => {
+    const stepIndex = Math.round(event.startTime / stepDuration);
+    if (stepIndex >= 0 && stepIndex < patternLength) {
+      const pos = GridMapService.noteToGrid(event.noteNumber, config);
+      if (pos) {
+        const [row, col] = pos;
+        steps[stepIndex][row][col] = true;
+      }
+    }
+  });
+  
+  return {
+    steps,
+    length: patternLength
   };
 };
 

--- a/src/workbench/GridArea.tsx
+++ b/src/workbench/GridArea.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GridEditor } from './GridEditor';
 import { LayoutSnapshot } from '../types/projectState';
-import { SectionMap } from '../types/performance';
+import { SectionMap } from '../data/models';
 import { GridPattern } from '../types/gridPattern';
 import { EngineResult } from '../engine/runEngine';
 

--- a/src/workbench/SectionMapList.tsx
+++ b/src/workbench/SectionMapList.tsx
@@ -1,78 +1,398 @@
-import React from 'react';
-import { SectionMap } from '../types/performance';
+import React, { useState, useEffect } from 'react';
+import { InstrumentConfig, SectionMap } from '../data/models';
+
+interface SectionMapItemProps {
+  section: SectionMap;
+  instrumentConfigs: InstrumentConfig[];
+  onUpdateSection: (id: string, updates: Partial<SectionMap> | { field: 'startMeasure' | 'lengthInMeasures' | 'bottomLeftNote'; value: number }) => void;
+  onDeleteSection?: (id: string) => void;
+}
+
+const SectionMapItem: React.FC<SectionMapItemProps> = ({
+  section,
+  instrumentConfigs,
+  onUpdateSection,
+  onDeleteSection,
+}) => {
+  // Use local state for input values to allow temporary empty values
+  const [localStartMeasure, setLocalStartMeasure] = useState(section.startMeasure.toString());
+  const [localLength, setLocalLength] = useState(section.lengthInMeasures.toString());
+  
+  // Sync local state when section prop changes
+  useEffect(() => {
+    setLocalStartMeasure(section.startMeasure.toString());
+  }, [section.startMeasure]);
+  
+  useEffect(() => {
+    setLocalLength(section.lengthInMeasures.toString());
+  }, [section.lengthInMeasures]);
+
+  return (
+    <div className="flex flex-col gap-2 p-3 bg-slate-800 rounded border border-slate-700 text-sm">
+      <div className="flex items-center justify-between text-slate-400 text-xs">
+        <span>{section.name || section.instrumentConfig.name}</span>
+      </div>
+      
+      <div className="grid grid-cols-2 gap-2">
+        <div className="flex flex-col">
+          <label className="text-xs text-slate-400 mb-1 font-medium">Start Bar</label>
+          <input
+            type="number"
+            className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+            value={localStartMeasure}
+            onChange={(e) => {
+              setLocalStartMeasure(e.target.value);
+            }}
+            onBlur={(e) => {
+              const val = e.target.value.trim();
+              const numVal = parseInt(val, 10);
+              if (val === '' || isNaN(numVal) || numVal < 1) {
+                // Restore to current value if empty or invalid
+                setLocalStartMeasure(section.startMeasure.toString());
+              } else {
+                // Update if valid
+                onUpdateSection(section.id, { field: 'startMeasure', value: numVal });
+              }
+            }}
+          />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-xs text-slate-400 mb-1 font-medium">Length (measures)</label>
+          <input
+            type="number"
+            className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+            value={localLength}
+            onChange={(e) => {
+              setLocalLength(e.target.value);
+            }}
+            onBlur={(e) => {
+              const val = e.target.value.trim();
+              const numVal = parseInt(val, 10);
+              if (val === '' || isNaN(numVal) || numVal < 1) {
+                // Restore to current value if empty or invalid
+                setLocalLength(section.lengthInMeasures.toString());
+              } else {
+                // Update if valid
+                onUpdateSection(section.id, { field: 'lengthInMeasures', value: numVal });
+              }
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col">
+        <label className="text-xs text-slate-500 mb-1">Instrument Config</label>
+        <select
+          className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+          value={section.instrumentConfig.id}
+          onChange={(e) => {
+            const selectedConfig = instrumentConfigs.find(c => c.id === e.target.value);
+            if (selectedConfig) {
+              onUpdateSection(section.id, { instrumentConfig: selectedConfig });
+            }
+          }}
+        >
+          {instrumentConfigs.map(config => (
+            <option key={config.id} value={config.id}>
+              {config.name} (Note {config.bottomLeftNote})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col">
+        <label className="text-xs text-slate-500 mb-1">Bottom Left Note (MIDI)</label>
+        <input
+          type="number"
+          className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+          value={section.instrumentConfig.bottomLeftNote}
+          onChange={(e) => onUpdateSection(section.id, { field: 'bottomLeftNote', value: parseInt(e.target.value) || 0 })}
+        />
+        <span className="text-[10px] text-slate-500 mt-1">
+          Editing the config's bottom left note directly
+        </span>
+      </div>
+      
+      {onDeleteSection && (
+        <button
+          onClick={() => {
+            if (window.confirm(`Delete section "${section.name || section.instrumentConfig.name}"?`)) {
+              onDeleteSection(section.id);
+            }
+          }}
+          className="mt-2 px-2 py-1 text-xs bg-red-900/30 hover:bg-red-900/50 text-red-300 rounded border border-red-900/50"
+        >
+          Delete
+        </button>
+      )}
+    </div>
+  );
+};
 
 interface SectionMapListProps {
   sectionMaps: SectionMap[];
-  onUpdateSection: (id: string, field: 'startMeasure' | 'endMeasure' | 'bottomLeftNote', value: number) => void;
+  instrumentConfigs: InstrumentConfig[];
+  onUpdateSection: (id: string, updates: Partial<SectionMap> | { field: 'startMeasure' | 'lengthInMeasures' | 'bottomLeftNote'; value: number }) => void;
   onDeleteSection?: (id: string) => void;
+  onCreateInstrumentConfig?: (config: Omit<InstrumentConfig, 'id'>) => void;
+  onCreateSectionMap?: (sectionMap: Omit<SectionMap, 'id'>) => void;
+  onUpdateInstrumentConfig?: (id: string, updates: Partial<InstrumentConfig>) => void;
+  onDeleteInstrumentConfig?: (id: string) => void;
 }
 
 export const SectionMapList: React.FC<SectionMapListProps> = ({
   sectionMaps,
+  instrumentConfigs,
   onUpdateSection,
   onDeleteSection,
+  onCreateInstrumentConfig,
+  onCreateSectionMap,
+  onUpdateInstrumentConfig,
+  onDeleteInstrumentConfig,
 }) => {
-  return (
-    <div className="flex flex-col gap-2 mt-4">
-      <h3 className="text-sm font-semibold text-slate-300">Section Maps</h3>
-      <div className="flex flex-col gap-2">
-        {sectionMaps.map((section) => (
-          <div
-            key={section.id}
-            className="flex flex-col gap-2 p-3 bg-slate-800 rounded border border-slate-700 text-sm"
-          >
-            <div className="flex items-center justify-between text-slate-400 text-xs">
-              <span>{section.instrumentConfig.name}</span>
-            </div>
-            
-            <div className="grid grid-cols-2 gap-2">
-              <div className="flex flex-col">
-                <label className="text-xs text-slate-500 mb-1">Start Bar</label>
-                <input
-                  type="number"
-                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
-                  value={section.startMeasure}
-                  onChange={(e) => onUpdateSection(section.id, 'startMeasure', parseInt(e.target.value) || 0)}
-                />
-              </div>
-              <div className="flex flex-col">
-                <label className="text-xs text-slate-500 mb-1">End Bar</label>
-                <input
-                  type="number"
-                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
-                  value={section.endMeasure}
-                  onChange={(e) => onUpdateSection(section.id, 'endMeasure', parseInt(e.target.value) || 0)}
-                />
-              </div>
-            </div>
+  const [showNewConfigForm, setShowNewConfigForm] = useState(false);
+  const [showNewSectionForm, setShowNewSectionForm] = useState(false);
+  const [newConfigName, setNewConfigName] = useState('');
+  const [newConfigBottomNote, setNewConfigBottomNote] = useState(36);
+  const [newSectionName, setNewSectionName] = useState('');
+  const [newSectionStart, setNewSectionStart] = useState(1);
+  const [newSectionLength, setNewSectionLength] = useState(4);
+  const [newSectionConfigId, setNewSectionConfigId] = useState<string>('');
 
-            <div className="flex flex-col">
-              <label className="text-xs text-slate-500 mb-1">Bottom Left Note (MIDI)</label>
+  const handleCreateConfig = () => {
+    if (!newConfigName.trim() || !onCreateInstrumentConfig) return;
+    
+    onCreateInstrumentConfig({
+      name: newConfigName.trim(),
+      rows: 8,
+      cols: 8,
+      bottomLeftNote: newConfigBottomNote,
+    });
+    
+    setNewConfigName('');
+    setNewConfigBottomNote(36);
+    setShowNewConfigForm(false);
+  };
+
+  const handleCreateSection = () => {
+    if (!newSectionName.trim() || !newSectionConfigId || !onCreateSectionMap) return;
+    
+    const selectedConfig = instrumentConfigs.find(c => c.id === newSectionConfigId);
+    if (!selectedConfig) return;
+    
+    onCreateSectionMap({
+      name: newSectionName.trim(),
+      startMeasure: newSectionStart,
+      lengthInMeasures: newSectionLength,
+      instrumentConfig: selectedConfig,
+    });
+    
+    setNewSectionName('');
+    setNewSectionStart(1);
+    setNewSectionLength(4);
+    setNewSectionConfigId('');
+    setShowNewSectionForm(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* W1: Instrument Configs Section */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-semibold text-slate-300">Instrument Configs</h3>
+          {onCreateInstrumentConfig && (
+            <button
+              onClick={() => setShowNewConfigForm(!showNewConfigForm)}
+              className="px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded"
+            >
+              + New Config
+            </button>
+          )}
+        </div>
+        
+        {showNewConfigForm && onCreateInstrumentConfig && (
+          <div className="p-3 bg-slate-800 rounded border border-slate-700 mb-2">
+            <div className="flex flex-col gap-2">
+              <input
+                type="text"
+                placeholder="Config name"
+                value={newConfigName}
+                onChange={(e) => setNewConfigName(e.target.value)}
+                className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                autoFocus
+              />
               <input
                 type="number"
+                placeholder="Bottom Left Note (MIDI)"
+                value={newConfigBottomNote}
+                onChange={(e) => setNewConfigBottomNote(parseInt(e.target.value) || 36)}
                 className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
-                value={section.instrumentConfig.bottomLeftNote}
-                onChange={(e) => onUpdateSection(section.id, 'bottomLeftNote', parseInt(e.target.value) || 0)}
               />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleCreateConfig}
+                  className="flex-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded"
+                >
+                  Create
+                </button>
+                <button
+                  onClick={() => {
+                    setShowNewConfigForm(false);
+                    setNewConfigName('');
+                    setNewConfigBottomNote(36);
+                  }}
+                  className="flex-1 px-2 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-slate-200 rounded"
+                >
+                  Cancel
+                </button>
+              </div>
             </div>
-            
-            {onDeleteSection && (
-              <button
-                onClick={() => {
-                  if (window.confirm(`Delete section "${section.instrumentConfig.name}"?`)) {
-                    onDeleteSection(section.id);
-                  }
-                }}
-                className="mt-2 px-2 py-1 text-xs bg-red-900/30 hover:bg-red-900/50 text-red-300 rounded border border-red-900/50"
-              >
-                Delete
-              </button>
-            )}
           </div>
-        ))}
-        {sectionMaps.length === 0 && (
-          <div className="text-xs text-slate-500 italic p-2">No sections defined.</div>
         )}
+
+        <div className="flex flex-col gap-2">
+          {instrumentConfigs.map((config) => (
+            <div
+              key={config.id}
+              className="flex flex-col gap-2 p-2 bg-slate-800 rounded border border-slate-700 text-xs"
+            >
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] text-slate-500">Name</label>
+                <input
+                  type="text"
+                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                  value={config.name}
+                  onChange={(e) => {
+                    if (onUpdateInstrumentConfig) {
+                      onUpdateInstrumentConfig(config.id, { name: e.target.value });
+                    }
+                  }}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[10px] text-slate-500">Bottom Left Note (MIDI)</label>
+                <input
+                  type="number"
+                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                  value={config.bottomLeftNote}
+                  onChange={(e) => {
+                    if (onUpdateInstrumentConfig) {
+                      onUpdateInstrumentConfig(config.id, { bottomLeftNote: parseInt(e.target.value) || 0 });
+                    }
+                  }}
+                />
+              </div>
+              {onDeleteInstrumentConfig && (
+                <button
+                  onClick={() => {
+                    if (window.confirm(`Delete config "${config.name}"?`)) {
+                      onDeleteInstrumentConfig(config.id);
+                    }
+                  }}
+                  className="mt-1 px-2 py-1 text-xs bg-red-900/30 hover:bg-red-900/50 text-red-300 rounded"
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          ))}
+          {instrumentConfigs.length === 0 && (
+            <div className="text-xs text-slate-500 italic p-2">No instrument configs defined.</div>
+          )}
+        </div>
+      </div>
+
+      {/* W1: Section Maps Section */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-semibold text-slate-300">Section Maps</h3>
+          {onCreateSectionMap && (
+            <button
+              onClick={() => setShowNewSectionForm(!showNewSectionForm)}
+              className="px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded"
+            >
+              + New Section
+            </button>
+          )}
+        </div>
+
+        {showNewSectionForm && onCreateSectionMap && (
+          <div className="p-3 bg-slate-800 rounded border border-slate-700 mb-2">
+            <div className="flex flex-col gap-2">
+              <input
+                type="text"
+                placeholder="Section name"
+                value={newSectionName}
+                onChange={(e) => setNewSectionName(e.target.value)}
+                className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                autoFocus
+              />
+              <select
+                value={newSectionConfigId}
+                onChange={(e) => setNewSectionConfigId(e.target.value)}
+                className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+              >
+                <option value="">Select Instrument Config</option>
+                {instrumentConfigs.map((config) => (
+                  <option key={config.id} value={config.id}>
+                    {config.name}
+                  </option>
+                ))}
+              </select>
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  type="number"
+                  placeholder="Start Measure"
+                  value={newSectionStart}
+                  onChange={(e) => setNewSectionStart(parseInt(e.target.value) || 1)}
+                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                />
+                <input
+                  type="number"
+                  placeholder="Length (measures)"
+                  value={newSectionLength}
+                  onChange={(e) => setNewSectionLength(parseInt(e.target.value) || 4)}
+                  className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-slate-200 text-xs focus:border-blue-500 outline-none"
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleCreateSection}
+                  className="flex-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded"
+                >
+                  Create
+                </button>
+                <button
+                  onClick={() => {
+                    setShowNewSectionForm(false);
+                    setNewSectionName('');
+                    setNewSectionStart(1);
+                    setNewSectionLength(4);
+                    setNewSectionConfigId('');
+                  }}
+                  className="flex-1 px-2 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-slate-200 rounded"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          {sectionMaps.map((section) => (
+            <SectionMapItem
+              key={section.id}
+              section={section}
+              instrumentConfigs={instrumentConfigs}
+              onUpdateSection={onUpdateSection}
+              onDeleteSection={onDeleteSection}
+            />
+          ))}
+          {sectionMaps.length === 0 && (
+            <div className="text-xs text-slate-500 italic p-2">No sections defined.</div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/workbench/Sidebar.tsx
+++ b/src/workbench/Sidebar.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { LayoutList } from './LayoutList';
 import { SectionMapList } from './SectionMapList';
 import { LayoutSnapshot } from '../types/projectState';
-import { SectionMap } from '../types/performance';
+import { SectionMap } from '../data/models';
 
 interface SidebarProps {
   layouts: LayoutSnapshot[];
@@ -11,7 +11,7 @@ interface SidebarProps {
   onSelectLayout: (id: string) => void;
   onCreateLayout: () => void;
   onDeleteLayout: (id: string) => void;
-  onUpdateSection: (id: string, field: 'startMeasure' | 'endMeasure' | 'bottomLeftNote', value: number) => void;
+  onUpdateSection: (id: string, updates: Partial<SectionMap> | { field: 'startMeasure' | 'lengthInMeasures' | 'bottomLeftNote'; value: number }) => void;
   onSaveProject: () => void;
   onLoadProject: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onImportMidi: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/workbench/Timeline.tsx
+++ b/src/workbench/Timeline.tsx
@@ -1,39 +1,63 @@
-import React, { useRef, useEffect, useState } from 'react';
-import { SectionMap } from '../types/performance';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
+import { SectionMap } from '../data/models';
 
 interface TimelineProps {
   steps: number;
   currentStep: number;
   onStepSelect: (step: number) => void;
   sectionMaps: SectionMap[];
+  /** W2: Callback to update section map boundaries */
+  onUpdateSectionMeasure?: (id: string, field: 'startMeasure' | 'lengthInMeasures', value: number) => void;
 }
 
 const STEPS_PER_MEASURE = 16; // Assuming 4/4 time signature and 16th notes
 const MIN_STEP_WIDTH = 12; // Minimum width per step in pixels
 const DEFAULT_STEPS = 64; // Default to 4 bars (64 steps at 16th note resolution)
+const OVERVIEW_PROJECT_LENGTH = 32; // Always show 32 bars in overview (512 steps)
+const VIEWPORT_SIZE_MEASURES = 4; // Default viewport size: 4 bars (can be changed to 4 or 8)
 
 export const Timeline: React.FC<TimelineProps> = ({
   steps: inputSteps,
   currentStep,
   onStepSelect,
   sectionMaps,
+  onUpdateSectionMeasure,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const stepsContainerRef = useRef<HTMLDivElement>(null);
+  const overviewStripRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [stepWidth, setStepWidth] = useState(0);
+  const [viewportStartMeasure, setViewportStartMeasure] = useState(1); // Which measure the viewport starts at
+  const [viewportSizeMeasures, setViewportSizeMeasures] = useState(VIEWPORT_SIZE_MEASURES); // 4 or 8 bars
 
   // Ensure minimum of 64 steps (4 bars) for default duration
   const steps = Math.max(inputSteps || DEFAULT_STEPS, DEFAULT_STEPS);
   const totalMeasures = Math.ceil(steps / STEPS_PER_MEASURE);
+  
+  // Project length for overview: use actual project length or 32 bars, whichever is larger
+  const projectLengthMeasures = Math.max(totalMeasures, OVERVIEW_PROJECT_LENGTH);
+  const projectLengthSteps = projectLengthMeasures * STEPS_PER_MEASURE;
+  
+  // Clamp viewport to project bounds
+  const clampedViewportStartMeasure = useMemo(() => {
+    const maxStart = Math.max(1, projectLengthMeasures - viewportSizeMeasures + 1);
+    return Math.max(1, Math.min(viewportStartMeasure, maxStart));
+  }, [viewportStartMeasure, projectLengthMeasures, viewportSizeMeasures]);
+  
+  // Viewport calculations (use clamped value)
+  const viewportStartStep = (clampedViewportStartMeasure - 1) * STEPS_PER_MEASURE;
+  const viewportSizeSteps = viewportSizeMeasures * STEPS_PER_MEASURE;
+  const viewportEndStep = viewportStartStep + viewportSizeSteps; // Don't clamp - allow viewport to extend beyond project
 
-  // Calculate responsive step width
+  // Calculate responsive step width for viewport (only show viewportSizeSteps)
   useEffect(() => {
     const updateStepWidth = () => {
       if (scrollContainerRef.current) {
         const container = scrollContainerRef.current;
         const availableWidth = container.clientWidth;
-        const calculatedWidth = availableWidth / steps;
+        // Calculate width based on viewport size, not full project
+        const calculatedWidth = availableWidth / viewportSizeSteps;
         const finalWidth = Math.max(calculatedWidth, MIN_STEP_WIDTH);
         setContainerWidth(availableWidth);
         setStepWidth(finalWidth);
@@ -47,110 +71,415 @@ export const Timeline: React.FC<TimelineProps> = ({
     }
 
     return () => resizeObserver.disconnect();
-  }, [steps]);
+  }, [viewportSizeSteps]);
 
-  // Auto-scroll to keep current step in view
+  // Auto-scroll viewport to keep current step in view
   useEffect(() => {
-    if (scrollContainerRef.current && stepWidth > 0) {
-      const container = scrollContainerRef.current;
-      const targetScroll = (currentStep * stepWidth) - (container.clientWidth / 2) + (stepWidth / 2);
-      container.scrollTo({
-        left: Math.max(0, targetScroll),
-        behavior: 'smooth'
-      });
+    if (currentStep < viewportStartStep || currentStep >= viewportEndStep) {
+      // Current step is outside viewport, adjust viewport
+      const targetMeasure = Math.floor(currentStep / STEPS_PER_MEASURE) + 1;
+      const newViewportStart = Math.max(1, targetMeasure - Math.floor(viewportSizeMeasures / 2));
+      setViewportStartMeasure(Math.min(newViewportStart, projectLengthMeasures - viewportSizeMeasures + 1));
     }
-  }, [currentStep, stepWidth]);
+  }, [currentStep, viewportStartStep, viewportEndStep, viewportSizeMeasures, projectLengthMeasures]);
 
-  // Calculate if we need scrolling (when steps hit min-width)
-  const needsScrolling = stepWidth === MIN_STEP_WIDTH;
-  const totalWidth = steps * stepWidth;
+  // Handle overview strip click/drag to change viewport
+  const [draggingOverview, setDraggingOverview] = useState(false);
+  
+  const handleOverviewClick = (e: React.MouseEvent) => {
+    if (!overviewStripRef.current) return;
+    const rect = overviewStripRef.current.getBoundingClientRect();
+    const relativeX = e.clientX - rect.left;
+    const overviewWidth = rect.width;
+    const clickedMeasure = Math.floor((relativeX / overviewWidth) * projectLengthMeasures) + 1;
+    const newViewportStart = Math.max(1, Math.min(clickedMeasure - Math.floor(viewportSizeMeasures / 2), projectLengthMeasures - viewportSizeMeasures + 1));
+    setViewportStartMeasure(newViewportStart);
+  };
+
+  const handleOverviewMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setDraggingOverview(true);
+    handleOverviewClick(e);
+  };
+
+  useEffect(() => {
+    if (!draggingOverview) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!overviewStripRef.current) return;
+      const rect = overviewStripRef.current.getBoundingClientRect();
+      const relativeX = e.clientX - rect.left;
+      const overviewWidth = rect.width;
+      const clickedMeasure = Math.floor((relativeX / overviewWidth) * projectLengthMeasures) + 1;
+      const newViewportStart = Math.max(1, Math.min(clickedMeasure - Math.floor(viewportSizeMeasures / 2), projectLengthMeasures - viewportSizeMeasures + 1));
+      setViewportStartMeasure(newViewportStart);
+    };
+
+    const handleMouseUp = () => {
+      setDraggingOverview(false);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [draggingOverview, viewportSizeMeasures, projectLengthMeasures]);
+
+  // W2: Handle dragging section boundaries
+  const [draggingBoundary, setDraggingBoundary] = useState<{
+    sectionId: string;
+    type: 'start' | 'end';
+  } | null>(null);
+
+  const handleBoundaryMouseDown = (e: React.MouseEvent, sectionId: string, type: 'start' | 'end') => {
+    e.stopPropagation();
+    if (!onUpdateSectionMeasure) return;
+    setDraggingBoundary({ sectionId, type });
+  };
+
+  useEffect(() => {
+    if (!draggingBoundary || !onUpdateSectionMeasure) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!scrollContainerRef.current || !stepsContainerRef.current) return;
+      
+      const containerRect = scrollContainerRef.current.getBoundingClientRect();
+      const relativeX = e.clientX - containerRect.left;
+      // Convert relative position to absolute step, accounting for viewport offset
+      const relativeStep = Math.floor(relativeX / stepWidth);
+      const absoluteStep = viewportStartStep + relativeStep;
+      const measure = Math.floor(absoluteStep / STEPS_PER_MEASURE) + 1;
+      const clampedMeasure = Math.max(1, Math.min(measure, projectLengthMeasures));
+
+      const section = sectionMaps.find(s => s.id === draggingBoundary.sectionId);
+      if (!section) return;
+
+      // Calculate endMeasure from startMeasure + lengthInMeasures
+      const endMeasure = section.startMeasure + section.lengthInMeasures - 1;
+
+      if (draggingBoundary.type === 'start') {
+        if (clampedMeasure < endMeasure) {
+          onUpdateSectionMeasure(section.id, 'startMeasure', clampedMeasure);
+        }
+      } else {
+        // When dragging end boundary, calculate new lengthInMeasures
+        if (clampedMeasure > section.startMeasure) {
+          const newLength = clampedMeasure - section.startMeasure + 1;
+          onUpdateSectionMeasure(section.id, 'lengthInMeasures', newLength);
+        }
+      }
+    };
+
+    const handleMouseUp = () => {
+      setDraggingBoundary(null);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [draggingBoundary, onUpdateSectionMeasure, stepWidth, sectionMaps, projectLengthMeasures, viewportStartStep]);
+
+  // Calculate viewport indicator position in overview strip
+  const overviewViewportLeft = ((clampedViewportStartMeasure - 1) / projectLengthMeasures) * 100;
+  const overviewViewportWidth = (viewportSizeMeasures / projectLengthMeasures) * 100;
 
   return (
     <div className="flex flex-col h-full w-full">
-      {/* Ruler / Measures */}
+      {/* Overview Strip - Always shows full 32-bar project */}
+      <div className="flex-none h-16 bg-slate-800 border-b border-slate-700 relative">
+        <div className="flex items-center gap-2 px-2 h-full">
+          <span className="text-xs text-slate-400 font-mono whitespace-nowrap">Overview:</span>
+          <div 
+            ref={overviewStripRef}
+            className="flex-1 h-10 bg-slate-900 rounded border border-slate-700 relative cursor-pointer overflow-hidden"
+            onMouseDown={handleOverviewMouseDown}
+          >
+            {/* Section boundaries in overview */}
+            {sectionMaps.map((section) => {
+              const endMeasure = section.startMeasure + section.lengthInMeasures - 1;
+              const sectionLeft = ((section.startMeasure - 1) / projectLengthMeasures) * 100;
+              const sectionWidth = ((endMeasure - section.startMeasure + 1) / projectLengthMeasures) * 100;
+              
+              return (
+                <div
+                  key={`overview-section-${section.id}`}
+                  className="absolute top-0 bottom-0 bg-blue-900/40 border-l border-r border-blue-700/50"
+                  style={{
+                    left: `${sectionLeft}%`,
+                    width: `${sectionWidth}%`,
+                  }}
+                  title={section.name || section.instrumentConfig.name}
+                />
+              );
+            })}
+            
+            {/* Measure markers in overview */}
+            {Array.from({ length: projectLengthMeasures }).map((_, i) => {
+              const measureLeft = (i / projectLengthMeasures) * 100;
+              return (
+                <div
+                  key={`overview-measure-${i}`}
+                  className="absolute top-0 bottom-0 border-l border-slate-700/50"
+                  style={{ left: `${measureLeft}%` }}
+                />
+              );
+            })}
+            
+            {/* Viewport indicator (shows what's visible in main timeline) */}
+            <div
+              className="absolute top-0 bottom-0 bg-yellow-500/30 border-2 border-yellow-400 pointer-events-none z-10"
+              style={{
+                left: `${overviewViewportLeft}%`,
+                width: `${overviewViewportWidth}%`,
+              }}
+            >
+              <div className="absolute top-0 left-0 right-0 h-3 bg-yellow-400/50 flex items-center justify-center">
+                <span className="text-[8px] font-mono text-yellow-200 font-semibold">
+                  {clampedViewportStartMeasure}-{clampedViewportStartMeasure + viewportSizeMeasures - 1}
+                </span>
+              </div>
+            </div>
+            
+            {/* Current step indicator in overview */}
+            {currentStep >= 0 && currentStep < projectLengthSteps && (
+              <div
+                className="absolute top-0 bottom-0 w-0.5 bg-blue-400 pointer-events-none z-20"
+                style={{
+                  left: `${(currentStep / projectLengthSteps) * 100}%`,
+                }}
+              />
+            )}
+          </div>
+          
+          {/* Viewport size toggle */}
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setViewportSizeMeasures(4)}
+              className={`px-2 py-1 text-xs rounded transition-colors ${
+                viewportSizeMeasures === 4
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+              }`}
+              title="4-bar viewport"
+            >
+              4
+            </button>
+            <button
+              onClick={() => setViewportSizeMeasures(8)}
+              className={`px-2 py-1 text-xs rounded transition-colors ${
+                viewportSizeMeasures === 8
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+              }`}
+              title="8-bar viewport"
+            >
+              8
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* W2: Measure Ruler (Top) - Shows only viewport measures, aligned to actual step positions */}
+      <div className="flex-none h-8 bg-slate-900 border-b border-slate-800 relative overflow-hidden">
+        <div 
+          className="relative h-full"
+          style={{ 
+            width: '100%',
+            minWidth: '100%'
+          }}
+        >
+          {/* Beat division markers (every 4 steps) */}
+          {Array.from({ length: viewportSizeSteps }).map((_, i) => {
+            const absoluteStep = viewportStartStep + i;
+            const isBeatStart = absoluteStep % 4 === 0;
+            const isMeasureStart = absoluteStep % STEPS_PER_MEASURE === 0;
+            
+            // Only show beat markers (not measure markers, those are handled separately)
+            if (!isBeatStart || isMeasureStart) return null;
+            
+            const relativeStep = i;
+            const beatLeft = relativeStep * stepWidth;
+            
+            return (
+              <div
+                key={`ruler-beat-${absoluteStep}`}
+                className="absolute top-0 bottom-0 border-l border-slate-700/40"
+                style={{ left: `${beatLeft}px` }}
+              />
+            );
+          })}
+          
+          {/* Measure markers */}
+          {Array.from({ length: viewportSizeMeasures }).map((_, i) => {
+            const measureNumber = clampedViewportStartMeasure + i;
+            // Calculate the actual step position for this measure start
+            const measureStartStep = (measureNumber - 1) * STEPS_PER_MEASURE;
+            // Only show if this measure start is within the viewport
+            if (measureStartStep < viewportStartStep || measureStartStep >= viewportEndStep) {
+              return null;
+            }
+            // Calculate pixel position relative to viewport start
+            const relativeStep = measureStartStep - viewportStartStep;
+            const measureLeft = relativeStep * stepWidth;
+            
+            return (
+              <div
+                key={`ruler-measure-${measureNumber}`}
+                className="absolute top-0 bottom-0 border-l border-slate-700 z-10"
+                style={{ left: `${measureLeft}px` }}
+              >
+                <span className="absolute top-1 left-1 text-xs text-slate-400 font-mono font-semibold">
+                  {measureNumber}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Timeline Content - Viewport (shows only viewportSizeMeasures bars) */}
       <div 
         ref={scrollContainerRef}
-        className={`flex-1 overflow-y-hidden relative bg-slate-950 border border-slate-800 rounded ${needsScrolling ? 'overflow-x-auto' : 'overflow-x-hidden'}`}
+        className="flex-1 overflow-hidden relative bg-slate-950 border border-slate-800 rounded"
       >
         <div 
           ref={stepsContainerRef}
           className="relative h-full w-full"
           style={{ 
-            width: needsScrolling ? `${totalWidth}px` : '100%',
+            width: '100%',
             minWidth: '100%'
           }}
         >
-          {/* Section Backgrounds */}
+          {/* W2: Section Backgrounds with Editable Boundaries (only show sections in viewport) */}
           {sectionMaps.map((section) => {
-            const startStep = (section.startMeasure - 1) * STEPS_PER_MEASURE;
-            const endStep = section.endMeasure * STEPS_PER_MEASURE;
-            const width = (endStep - startStep) * stepWidth;
-            const left = startStep * stepWidth;
+            // Calculate endMeasure from startMeasure + lengthInMeasures
+            const endMeasure = section.startMeasure + section.lengthInMeasures - 1;
+            const sectionStartStep = (section.startMeasure - 1) * STEPS_PER_MEASURE;
+            const sectionEndStep = endMeasure * STEPS_PER_MEASURE;
+            
+            // Check if section overlaps with viewport
+            if (sectionEndStep < viewportStartStep || sectionStartStep >= viewportEndStep) {
+              return null; // Section is outside viewport
+            }
+            
+            // Calculate relative position within viewport
+            const relativeStartStep = Math.max(0, sectionStartStep - viewportStartStep);
+            const relativeEndStep = Math.min(viewportSizeSteps, sectionEndStep - viewportStartStep);
+            const width = (relativeEndStep - relativeStartStep) * stepWidth;
+            const left = relativeStartStep * stepWidth;
 
             return (
               <div
                 key={section.id}
-                className="absolute top-0 bottom-0 bg-blue-900/20 border-l border-r border-blue-900/30 pointer-events-none z-0"
+                className="absolute top-0 bottom-0 bg-blue-900/20 border-l border-r border-blue-900/30 z-0"
                 style={{ 
                   left: `${left}px`, 
                   width: `${width}px`,
-                  minWidth: needsScrolling ? `${width}px` : undefined
                 }}
               >
-                <div className="absolute top-1 left-2 text-xs text-blue-400/50 font-mono truncate">
-                  {section.instrumentConfig.name}
+                <div className="absolute top-1 left-2 text-xs text-blue-400/50 font-mono truncate pointer-events-none">
+                  {section.name || section.instrumentConfig.name}
                 </div>
+                
+                {/* W2: Editable Start Boundary */}
+                {onUpdateSectionMeasure && (
+                  <>
+                    <div
+                      onMouseDown={(e) => handleBoundaryMouseDown(e, section.id, 'start')}
+                      className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-blue-500/50 z-20"
+                      style={{ cursor: draggingBoundary?.sectionId === section.id && draggingBoundary?.type === 'start' ? 'grabbing' : 'grab' }}
+                    />
+                    {/* W2: Editable End Boundary */}
+                    <div
+                      onMouseDown={(e) => handleBoundaryMouseDown(e, section.id, 'end')}
+                      className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-blue-500/50 z-20"
+                      style={{ cursor: draggingBoundary?.sectionId === section.id && draggingBoundary?.type === 'end' ? 'grabbing' : 'grab' }}
+                    />
+                  </>
+                )}
               </div>
             );
           })}
 
-          {/* Measure Markers (Bar Lines) */}
-          {Array.from({ length: totalMeasures }).map((_, i) => {
-            const measureLeft = i * STEPS_PER_MEASURE * stepWidth;
+          {/* Measure Markers (Bar Lines) - Only show measures in viewport, aligned to actual step positions */}
+          {Array.from({ length: viewportSizeMeasures }).map((_, i) => {
+            const measureNumber = clampedViewportStartMeasure + i;
+            // Calculate the actual step position for this measure start
+            const measureStartStep = (measureNumber - 1) * STEPS_PER_MEASURE;
+            // Only show if this measure start is within the viewport
+            if (measureStartStep < viewportStartStep || measureStartStep >= viewportEndStep) {
+              return null;
+            }
+            // Calculate pixel position relative to viewport start
+            const relativeStep = measureStartStep - viewportStartStep;
+            const measureLeft = relativeStep * stepWidth;
+            
             return (
               <div
-                key={`measure-${i}`}
+                key={`measure-${measureNumber}`}
                 className="absolute top-0 bottom-0 border-l-2 border-slate-600 pointer-events-none z-10"
                 style={{ left: `${measureLeft}px` }}
               >
                 <span className="absolute top-0 left-1 text-xs text-slate-500 font-mono font-semibold">
-                  {i + 1}
+                  {measureNumber}
                 </span>
               </div>
             );
           })}
 
-          {/* Steps */}
-          <div className="absolute bottom-0 left-0 h-12 flex items-end w-full" style={{ width: needsScrolling ? `${totalWidth}px` : '100%' }}>
-            {Array.from({ length: steps }).map((_, i) => {
-              const isMeasureStart = i % STEPS_PER_MEASURE === 0;
-              const isBeatStart = i % 4 === 0;
+          {/* Steps - Only show steps in viewport */}
+          <div className="absolute bottom-0 left-0 h-12 flex items-end w-full" style={{ width: '100%' }}>
+            {Array.from({ length: viewportSizeSteps }).map((_, i) => {
+              const absoluteStep = viewportStartStep + i;
+              // Check if step is within project bounds
+              const isWithinProject = absoluteStep < steps;
+              
+              const isMeasureStart = absoluteStep % STEPS_PER_MEASURE === 0;
+              const isBeatStart = absoluteStep % 4 === 0;
+              const isCurrentStep = absoluteStep === currentStep;
               
               return (
                 <div
-                  key={`step-${i}`}
+                  key={`step-${absoluteStep}`}
                   className={`
-                    relative h-8 border-r border-slate-800 cursor-pointer hover:bg-slate-800 transition-colors flex-shrink-0
-                    ${i === currentStep ? 'bg-blue-600 hover:bg-blue-500' : ''}
+                    relative h-8 border-r border-slate-800 transition-colors flex-shrink-0
+                    ${isWithinProject ? 'cursor-pointer hover:bg-slate-800' : 'bg-slate-950 border-slate-900'}
+                    ${isCurrentStep && isWithinProject ? 'bg-blue-600 hover:bg-blue-500' : ''}
                   `}
                   style={{ 
-                    width: needsScrolling ? `${MIN_STEP_WIDTH}px` : `${stepWidth}px`,
+                    width: `${stepWidth}px`,
                     minWidth: `${MIN_STEP_WIDTH}px`
                   }}
-                  onClick={() => onStepSelect(i)}
+                  onClick={() => {
+                    if (isWithinProject) {
+                      onStepSelect(absoluteStep);
+                    }
+                  }}
                 >
                   {/* Bar Line Marker (every 16 steps) */}
                   {isMeasureStart && (
-                    <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-slate-500 z-20" />
+                    <div className={`absolute left-0 top-0 bottom-0 w-0.5 z-20 ${isWithinProject ? 'bg-slate-500' : 'bg-slate-800'}`} />
                   )}
                   
-                  {/* Step Number (every 4 steps) */}
-                  {isBeatStart && (
+                  {/* Beat Division Marker (every 4 steps, but not on measure start) */}
+                  {isBeatStart && !isMeasureStart && (
+                    <div className={`absolute left-0 top-0 bottom-0 w-px z-15 ${isWithinProject ? 'bg-slate-600/60' : 'bg-slate-800/40'}`} />
+                  )}
+                  
+                  {/* Step Number (every 4 steps) - only show if within project */}
+                  {isBeatStart && isWithinProject && (
                     <span className={`
                       absolute bottom-1 left-1 text-[10px] font-mono pointer-events-none
-                      ${i === currentStep ? 'text-white' : 'text-slate-600'}
+                      ${isCurrentStep ? 'text-white' : 'text-slate-600'}
                     `}>
-                      {(i % STEPS_PER_MEASURE) / 4 + 1}
+                      {(absoluteStep % STEPS_PER_MEASURE) / 4 + 1}
                     </span>
                   )}
                 </div>

--- a/src/workbench/TimelineArea.tsx
+++ b/src/workbench/TimelineArea.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Timeline } from './Timeline';
-import { SectionMap } from '../types/performance';
+import { SectionMap } from '../data/models';
 
 interface TimelineAreaProps {
   steps: number;
   currentStep: number;
   onStepSelect: (step: number) => void;
   sectionMaps: SectionMap[];
+  /** W2: Callback to update section map boundaries */
+  onUpdateSectionMeasure?: (id: string, field: 'startMeasure' | 'lengthInMeasures', value: number) => void;
 }
 
 export const TimelineArea: React.FC<TimelineAreaProps> = ({
@@ -14,6 +16,7 @@ export const TimelineArea: React.FC<TimelineAreaProps> = ({
   currentStep,
   onStepSelect,
   sectionMaps,
+  onUpdateSectionMeasure,
 }) => {
   return (
     <div id="timeline-area" className="h-full bg-slate-900 p-4 border-t border-border flex flex-col">
@@ -23,6 +26,7 @@ export const TimelineArea: React.FC<TimelineAreaProps> = ({
           currentStep={currentStep}
           onStepSelect={onStepSelect}
           sectionMaps={sectionMaps}
+          onUpdateSectionMeasure={onUpdateSectionMeasure}
         />
       </div>
     </div>


### PR DESCRIPTION
- W1: Section Map Management UI
  - Added InstrumentConfig and SectionMap management controls
  - Users can create, edit, and delete InstrumentConfigs
  - Users can create, edit, and delete SectionMaps with measure boundaries
  - SectionMap now uses lengthInMeasures instead of endMeasure

- W2: Timeline & Measure Ruler
  - Implemented scrollable viewport with 4-bar default (toggleable to 8-bar)
  - Added Overview Strip showing full 32-bar project with section boundaries
  - Overview strip allows clicking/dragging to navigate viewport
  - Measure ruler and beat divisions always visible and properly aligned
  - Editable section markers with draggable boundaries

- W3: MIDI Import & Mapping Check
  - Added warning UI for notes outside 8x8 grid window
  - parseMidiFile now returns unmappedNoteCount
  - Clear warnings displayed when importing MIDI files

- W4: 8x8 Grid Feedback
  - Per-pad note count displayed on grid cells
  - Shows total NoteEvents mapped to each pad

- W5: Performance ↔ Grid Sync
  - Bidirectional sync between Performance and GridPattern
  - Added performanceToGridPattern conversion function
  - Auto-syncs when Performance changes using active InstrumentConfig

- Additional fixes:
  - Fixed beat division visibility issues
  - Improved InstrumentConfig editing with proper input handling
  - Fixed SectionMap editing with local state for better UX
  - Enhanced label visibility and styling