### PR TITLE
Refine beam cost tracking and add rudiment-generation scaffold

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,3 +191,24 @@ System iterates original MIDI.
 Lookup: Note 36 $\rightarrow$ Asset "Kick" $\rightarrow$ Grid [0,1] $\rightarrow$ New Note 37.
 
 Browser downloads Song_Remapped.mid.
+7. Current Codebase Organization (2026 update)
+
+- `src/engine/`: core biomechanics, cost model, feasibility checks, and pluggable solver strategies (`beam`, `genetic`, `annealing`).
+- `src/context/ProjectContext.tsx`: orchestration layer that runs solvers and stores per-solver results.
+- `src/workbench/` + `src/components/`: UI surfaces for layout, analysis, and timeline inspection.
+- `src/utils/`: adapters and converters for MIDI, grid patterns, persistence, and formatting.
+- `docs/`: architecture notes, milestone history, and roadmap artifacts.
+
+8. Redundancy Cleanup Notes
+
+- Beam solver cost reporting previously reconstructed synthetic percentages in `buildResult` instead of using true tracked costs.
+- Cost breakdown is now captured at assignment generation time and propagated directly into debug events.
+- `core.ts` facade formatting had stray brace/indent artifacts; class and factory boundaries were normalized for readability.
+
+9. Pivot Readiness: Rudiment Generation via Biomechanics
+
+- Added an engine-native rudiment module (`src/engine/rudiments.ts`) with:
+  - reusable rudiment library definitions,
+  - rudiment-to-performance generation,
+  - direct evaluation through `BiomechanicalSolver`.
+- This creates a clean pathway for skill-building content where generated rudiments are scored by the same biomechanical cost engine used for layout optimization.

--- a/src/engine/core.ts
+++ b/src/engine/core.ts
@@ -111,8 +111,8 @@ export class BiomechanicalSolver {
     };
     
     this.strategy = resolveSolver(solverType, solverConfig);
-        }
-        
+  }
+
   /**
    * Gets the current solver strategy name.
    */
@@ -246,4 +246,4 @@ export function createBiomechanicalSolverWithStrategy(
     engineConfig,
     solverType
   );
-  }
+}

--- a/src/engine/costFunction.ts
+++ b/src/engine/costFunction.ts
@@ -660,7 +660,7 @@ export function calculateTransitionCost(
  */
 export function calculateGripStretchCost(
   pose: HandPose,
-  handSide: 'left' | 'right',
+  handSide: 'left' | 'right' = 'right',
   idealSpan: number = 2.0,
   maxSpan: number = 5.5,
   neutralHandCenters?: NeutralHandCenters | null
@@ -751,7 +751,7 @@ export function calculateTotalGripCost(
   }
   
   const attractorCost = calculateAttractorCost(curr, resting, stiffness);
-  const stretchCost = calculateGripStretchCost(curr);
+  const stretchCost = calculateGripStretchCost(curr, 'right');
   
   // Combine costs with equal weighting
   // Could be extended with configurable weights
@@ -803,4 +803,3 @@ export function handStateToHandPose(handState: HandState): HandPose {
   
   return { centroid, fingers };
 }
-

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -74,3 +74,16 @@ export {
   SPEED_COST_WEIGHT,
   FALLBACK_GRIP_PENALTY,
 } from './costFunction';
+
+// Rudiment generation and evaluation
+export {
+  RUDIMENT_LIBRARY,
+  generateRudimentPerformance,
+  evaluateRudimentWithBiomechanics,
+} from './rudiments';
+export type {
+  RudimentToken,
+  RudimentDefinition,
+  RudimentGenerationOptions,
+  RudimentEvaluation,
+} from './rudiments';

--- a/src/engine/rudiments.ts
+++ b/src/engine/rudiments.ts
@@ -1,0 +1,134 @@
+import { BiomechanicalSolver } from './core';
+import { GridMapService } from './gridMapService';
+import { EngineResult, SolverType } from './solvers/types';
+import { GridMapping } from '../types/layout';
+import { InstrumentConfig, Performance } from '../types/performance';
+
+export type RudimentToken = 'R' | 'L' | 'RR' | 'LL' | 'RL' | 'LR' | '-';
+
+export interface RudimentDefinition {
+  id: string;
+  name: string;
+  description: string;
+  sticking: RudimentToken[];
+}
+
+export interface RudimentGenerationOptions {
+  bpm: number;
+  subdivision: 4 | 8 | 16;
+  noteNumber?: number;
+  bars?: number;
+  solverType?: SolverType;
+}
+
+export interface RudimentEvaluation {
+  rudiment: RudimentDefinition;
+  performance: Performance;
+  solverResult: EngineResult;
+}
+
+export const RUDIMENT_LIBRARY: RudimentDefinition[] = [
+  {
+    id: 'single-stroke-roll',
+    name: 'Single Stroke Roll',
+    description: 'Alternating strokes for timing and hand symmetry.',
+    sticking: ['R', 'L', 'R', 'L', 'R', 'L', 'R', 'L'],
+  },
+  {
+    id: 'double-stroke-roll',
+    name: 'Double Stroke Roll',
+    description: 'Two strokes per hand to train rebound control.',
+    sticking: ['RR', 'LL', 'RR', 'LL'],
+  },
+  {
+    id: 'single-paradiddle',
+    name: 'Single Paradiddle',
+    description: 'Classic RLRR / LRLL phrase for control and transitions.',
+    sticking: ['R', 'L', 'R', 'RR', 'L', 'R', 'L', 'LL'],
+  },
+  {
+    id: 'paradiddle-diddle',
+    name: 'Paradiddle-Diddle',
+    description: 'RLRRLL / LRLLRR hybrid for flow and accents.',
+    sticking: ['R', 'L', 'RR', 'LL', 'L', 'R', 'LL', 'RR'],
+  },
+];
+
+function normalizeStickToken(token: RudimentToken): Array<'left' | 'right'> {
+  switch (token) {
+    case 'R':
+      return ['right'];
+    case 'L':
+      return ['left'];
+    case 'RR':
+      return ['right', 'right'];
+    case 'LL':
+      return ['left', 'left'];
+    case 'RL':
+      return ['right', 'left'];
+    case 'LR':
+      return ['left', 'right'];
+    default:
+      return [];
+  }
+}
+
+function getDefaultCenterNote(config: InstrumentConfig): number {
+  const centerRow = Math.floor(config.rows / 2);
+  const centerCol = Math.floor(config.cols / 2);
+  return GridMapService.getNoteForPosition(centerRow, centerCol, config);
+}
+
+export function generateRudimentPerformance(
+  rudiment: RudimentDefinition,
+  config: InstrumentConfig,
+  options: RudimentGenerationOptions
+): Performance {
+  const bars = options.bars ?? 1;
+  const bpm = options.bpm;
+  const noteNumber = options.noteNumber ?? getDefaultCenterNote(config);
+  const stepDuration = (60 / bpm) * (4 / options.subdivision);
+  const events: Performance['events'] = [];
+
+  for (let bar = 0; bar < bars; bar++) {
+    for (let tokenIndex = 0; tokenIndex < rudiment.sticking.length; tokenIndex++) {
+      const token = rudiment.sticking[tokenIndex];
+      const resolvedStrokes = normalizeStickToken(token);
+      const tokenStart = (bar * rudiment.sticking.length + tokenIndex) * stepDuration;
+
+      for (let strokeIndex = 0; strokeIndex < resolvedStrokes.length; strokeIndex++) {
+        events.push({
+          noteNumber,
+          startTime: tokenStart + strokeIndex * (stepDuration / Math.max(1, resolvedStrokes.length)),
+          velocity: 96,
+          duration: stepDuration * 0.8,
+        });
+      }
+    }
+  }
+
+  return {
+    name: `${rudiment.name} @ ${bpm} BPM`,
+    tempo: bpm,
+    events,
+  };
+}
+
+export async function evaluateRudimentWithBiomechanics(
+  rudiment: RudimentDefinition,
+  instrumentConfig: InstrumentConfig,
+  engineConfig: ConstructorParameters<typeof BiomechanicalSolver>[3],
+  options: RudimentGenerationOptions,
+  gridMapping: GridMapping | null = null
+): Promise<RudimentEvaluation> {
+  const solverType = options.solverType ?? 'beam';
+  const performance = generateRudimentPerformance(rudiment, instrumentConfig, options);
+  const solver = new BiomechanicalSolver(instrumentConfig, gridMapping, undefined, engineConfig, solverType);
+  const solverResult = await solver.solveAsync(performance);
+
+  return {
+    rudiment,
+    performance,
+    solverResult,
+  };
+}

--- a/src/engine/solvers/BeamSolver.ts
+++ b/src/engine/solvers/BeamSolver.ts
@@ -46,8 +46,50 @@ interface NoteAssignment {
   finger: FingerType;
   grip: HandPose;
   cost: number;
+  costBreakdown: CostBreakdown;
   row: number;
   col: number;
+}
+
+interface BeamStepCost {
+  movement: number;
+  stretch: number;
+  drift: number;
+  bounce: number;
+  fatigue: number;
+  crossover: number;
+  total: number;
+}
+
+function createStepCost(
+  movement: number,
+  stretch: number,
+  drift: number,
+  fallbackPenalty: number = 0
+): BeamStepCost {
+  const crossover = fallbackPenalty;
+  const total = movement + stretch + drift + crossover;
+  return {
+    movement,
+    stretch,
+    drift,
+    bounce: 0,
+    fatigue: 0,
+    crossover,
+    total,
+  };
+}
+
+function splitStepCostAcrossNotes(stepCost: BeamStepCost, noteCount: number): CostBreakdown {
+  return {
+    movement: stepCost.movement / noteCount,
+    stretch: stepCost.stretch / noteCount,
+    drift: stepCost.drift / noteCount,
+    bounce: stepCost.bounce / noteCount,
+    fatigue: stepCost.fatigue / noteCount,
+    crossover: stepCost.crossover / noteCount,
+    total: stepCost.total / noteCount,
+  };
 }
 
 /**
@@ -267,14 +309,14 @@ export class BeamSolver implements SolverStrategy {
         // Use 0 transition cost for first group if infinite
         const effectiveTransitionCost = transitionCost === Infinity ? 0 : transitionCost;
 
-        const attractorCost = calculateAttractorCost(grip, restPose, stiffness);
-        const staticCost = calculateGripStretchCost(grip, hand, undefined, undefined, neutralHandCenters);
+        const driftCost = calculateAttractorCost(grip, restPose, stiffness);
+        const stretchCost = calculateGripStretchCost(grip, hand, undefined, undefined, neutralHandCenters);
         
         // Apply fallback penalty if this is a fallback grip
         const fallbackPenalty = isFallback ? FALLBACK_GRIP_PENALTY : 0;
 
-        const stepCost = effectiveTransitionCost + attractorCost + staticCost + fallbackPenalty;
-        const newTotalCost = node.totalCost + stepCost;
+        const stepCost = createStepCost(effectiveTransitionCost, stretchCost, driftCost, fallbackPenalty);
+        const newTotalCost = node.totalCost + stepCost.total;
 
         // Get fingers from grip for assignment
         const gripFingers = Object.keys(grip.fingers) as FingerType[];
@@ -283,7 +325,7 @@ export class BeamSolver implements SolverStrategy {
         // Create assignments for ALL notes in the group (handles chords correctly)
         // Each note in the chord gets its own assignment with the appropriate finger
         const assignments: NoteAssignment[] = [];
-        const costPerNote = stepCost / group.notes.length; // Distribute cost across notes
+        const costPerNote = splitStepCostAcrossNotes(stepCost, group.notes.length);
         
         for (let i = 0; i < group.notes.length; i++) {
           const event = group.notes[i];
@@ -300,7 +342,8 @@ export class BeamSolver implements SolverStrategy {
             hand,
             finger,
             grip,
-            cost: costPerNote,
+            cost: costPerNote.total,
+            costBreakdown: costPerNote,
             row: position.row,
             col: position.col,
           });
@@ -376,23 +419,25 @@ export class BeamSolver implements SolverStrategy {
         const effectiveLeftTransition = leftTransition === Infinity ? 0 : leftTransition;
         const effectiveRightTransition = rightTransition === Infinity ? 0 : rightTransition;
         
-        const leftAttractor = calculateAttractorCost(leftResult.pose, restingPose.left, stiffness);
-        const rightAttractor = calculateAttractorCost(rightResult.pose, restingPose.right, stiffness);
-        const leftStatic = calculateGripStretchCost(leftResult.pose, 'left', undefined, undefined, neutralHandCenters);
-        const rightStatic = calculateGripStretchCost(rightResult.pose, 'right', undefined, undefined, neutralHandCenters);
+        const leftDrift = calculateAttractorCost(leftResult.pose, restingPose.left, stiffness);
+        const rightDrift = calculateAttractorCost(rightResult.pose, restingPose.right, stiffness);
+        const leftStretch = calculateGripStretchCost(leftResult.pose, 'left', undefined, undefined, neutralHandCenters);
+        const rightStretch = calculateGripStretchCost(rightResult.pose, 'right', undefined, undefined, neutralHandCenters);
         
         // Apply fallback penalties
         const leftFallbackPenalty = leftResult.isFallback ? FALLBACK_GRIP_PENALTY : 0;
         const rightFallbackPenalty = rightResult.isFallback ? FALLBACK_GRIP_PENALTY : 0;
         
-        const stepCost = effectiveLeftTransition + effectiveRightTransition + 
-                         leftAttractor + rightAttractor + 
-                         leftStatic + rightStatic +
-                         leftFallbackPenalty + rightFallbackPenalty;
+        const stepCost = createStepCost(
+          effectiveLeftTransition + effectiveRightTransition,
+          leftStretch + rightStretch,
+          leftDrift + rightDrift,
+          leftFallbackPenalty + rightFallbackPenalty
+        );
         
         // Create assignments for ALL notes in the split chord
         const assignments: NoteAssignment[] = [];
-        const costPerNote = stepCost / group.notes.length;
+        const costPerNote = splitStepCostAcrossNotes(stepCost, group.notes.length);
         
         // Get fingers from both grips
         const leftFingers = Object.keys(leftResult.pose.fingers) as FingerType[];
@@ -418,7 +463,8 @@ export class BeamSolver implements SolverStrategy {
             hand,
             finger,
             grip,
-            cost: costPerNote,
+            cost: costPerNote.total,
+            costBreakdown: costPerNote,
             row: position.row,
             col: position.col,
           });
@@ -427,7 +473,7 @@ export class BeamSolver implements SolverStrategy {
         children.push({
           leftPose: leftResult.pose,
           rightPose: rightResult.pose,
-          totalCost: node.totalCost + stepCost,
+          totalCost: node.totalCost + stepCost.total,
           parent: node,
           assignments, // All assignments for the split chord
           depth: node.depth + 1,
@@ -576,17 +622,8 @@ export class BeamSolver implements SolverStrategy {
       totalDrift += drift;
       driftCount++;
 
-      // Cost breakdown (approximated for beam search - actual component costs
-      // are not tracked during beam search, so we use percentage estimates)
-      const costBreakdown: CostBreakdown = {
-        movement: assignment.cost * 0.4, // Approximate: movement typically 40% of total
-        stretch: assignment.cost * 0.2,  // Approximate: stretch typically 20% of total
-        drift: assignment.cost * 0.2,     // Approximate: drift typically 20% of total
-        bounce: 0,                         // Not tracked in beam search
-        fatigue: assignment.cost * 0.1,   // Approximate: fatigue typically 10% of total
-        crossover: assignment.cost * 0.1, // Approximate: crossover typically 10% of total
-        total: assignment.cost,
-      };
+      // Cost breakdown is tracked at assignment creation time from real beam-step components.
+      const costBreakdown: CostBreakdown = assignment.costBreakdown;
 
       totalMetrics.movement += costBreakdown.movement;
       totalMetrics.stretch += costBreakdown.stretch;
@@ -751,15 +788,15 @@ export class BeamSolver implements SolverStrategy {
                 : config.restingPose.right;
 
               const transitionCost = calculateTransitionCost(prevPose, matchingResult.pose, timeDelta);
-              const attractorCost = calculateAttractorCost(matchingResult.pose, restPose, config.stiffness);
-              const staticCost = calculateGripStretchCost(matchingResult.pose, override.hand, undefined, undefined, neutralHandCenters);
+              const driftCost = calculateAttractorCost(matchingResult.pose, restPose, config.stiffness);
+              const stretchCost = calculateGripStretchCost(matchingResult.pose, override.hand, undefined, undefined, neutralHandCenters);
               const fallbackPenalty = matchingResult.isFallback ? FALLBACK_GRIP_PENALTY : 0;
               const effectiveTransition = transitionCost === Infinity ? 100 : transitionCost;
-              const stepCost = effectiveTransition + attractorCost + staticCost + fallbackPenalty;
+              const stepCost = createStepCost(effectiveTransition, stretchCost, driftCost, fallbackPenalty);
 
               // Create assignments for ALL notes in the group (handles chords)
               const assignments: NoteAssignment[] = [];
-              const costPerNote = stepCost / group.notes.length;
+              const costPerNote = splitStepCostAcrossNotes(stepCost, group.notes.length);
               const gripFingers = Object.keys(matchingResult.pose.fingers) as FingerType[];
               
               for (let i = 0; i < group.notes.length; i++) {
@@ -770,7 +807,8 @@ export class BeamSolver implements SolverStrategy {
                   hand: override.hand,
                   finger: gripFingers[i % gripFingers.length] || override.finger,
                   grip: matchingResult.pose,
-                  cost: costPerNote,
+                  cost: costPerNote.total,
+                  costBreakdown: costPerNote,
                   row: group.positions[i].row,
                   col: group.positions[i].col,
                 });
@@ -779,7 +817,7 @@ export class BeamSolver implements SolverStrategy {
               newBeam.push({
                 leftPose: override.hand === 'left' ? matchingResult.pose : node.leftPose,
                 rightPose: override.hand === 'right' ? matchingResult.pose : node.rightPose,
-                totalCost: node.totalCost + stepCost,
+                totalCost: node.totalCost + stepCost.total,
                 parent: node,
                 assignments,
                 depth: node.depth + 1,
@@ -807,7 +845,8 @@ export class BeamSolver implements SolverStrategy {
         // Emergency fallback: create minimal assignments for ALL notes in group
         for (const node of beam) {
           const assignments: NoteAssignment[] = [];
-          const costPerNote = FALLBACK_GRIP_PENALTY / group.notes.length;
+          const stepCost = createStepCost(0, 0, 0, FALLBACK_GRIP_PENALTY);
+          const costPerNote = splitStepCostAcrossNotes(stepCost, group.notes.length);
           
           for (let i = 0; i < group.notes.length; i++) {
             const fallbackGrip: HandPose = {
@@ -828,7 +867,8 @@ export class BeamSolver implements SolverStrategy {
               hand,
               finger: 'index',
               grip: fallbackGrip,
-              cost: costPerNote,
+              cost: costPerNote.total,
+              costBreakdown: costPerNote,
               row: group.positions[i].row,
               col: group.positions[i].col,
             });
@@ -881,4 +921,3 @@ export class BeamSolver implements SolverStrategy {
 export function createBeamSolver(config: SolverConfig): BeamSolver {
   return new BeamSolver(config);
 }
-


### PR DESCRIPTION
### Motivation

- Replace ad-hoc percentage cost estimates reconstructed in the Beam solver with real, per-step biomechanical cost components to improve accuracy and transparency of scoring.
- Consolidate cost propagation so chord, manual-override, and fallback paths produce consistent breakdowns usable by tooling and visualization.
- Prepare the engine to drive a new product pivot: generate and evaluate practice rudiments using the same biomechanical model used for layout optimization.

### Description

- Beam solver: track per-step cost components (`movement`, `stretch`, `drift`, `fallback/crossover`) via `BeamStepCost` and propagate a per-note `CostBreakdown` into each assignment and debug event, replacing synthetic percentage reconstruction. (updates in `src/engine/solvers/BeamSolver.ts`).
- Aligned cost pipeline across all expansion paths including split-hand chords, manual overrides, and emergency fallback so all assignments carry the same detailed breakdown.
- Added a rudiment module (`src/engine/rudiments.ts`) providing a small starter library, `generateRudimentPerformance()`, and `evaluateRudimentWithBiomechanics()` for running generated rudiments through the BiomechanicalSolver.
- Engine entrypoint exports the new rudiment API and types (`src/engine/index.ts`) and a tiny cleanup/fix in the solver facade and cost function to remove a stray brace and to provide a safe default `handSide` param to `calculateGripStretchCost` (`src/engine/core.ts`, `src/engine/costFunction.ts`).
- Documented repository organization, the redundancy cleanup rationale, and the rudiment pivot readiness in `docs/ARCHITECTURE.md`.

### Testing

- Ran targeted TypeScript checks: `npx tsc --noEmit --skipLibCheck src/engine/solvers/BeamSolver.ts src/engine/rudiments.ts src/engine/core.ts src/engine/costFunction.ts` which completed successfully for the modified files. 
- Attempted full build with `npm run build`, which failed due to pre-existing, repo-wide TypeScript/test configuration issues unrelated to these changes (no changes introduced to front-end UI code); those failures are external to the modifications in this PR.
- Verified locally that the new rudiment generation compiles and the Beam solver changes type-check for the updated paths; cost breakdowns are now attached to `EngineDebugEvent` instances produced by the Beam solver.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855564990083219467a6fbf14a817f)