### PR TITLE
feat(pose): built-in default pose, remove import/export UI

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,81 @@
+# Route consistency + validation hardening
+
+## Summary
+
+Surgical fixes to enforce state consistency across routes, stabilize event identity, unify hydration, and harden project file validation and error UX.
+
+---
+
+## Decisions (locked in)
+
+| Decision | Rule |
+|----------|------|
+| **A — Mapping selection** | Every page that needs a mapping resolves it via `projectState.activeMappingId`. Fallback to first mapping only if `activeMappingId` is missing or invalid. |
+| **B — Event identity** | Manual assignments are keyed by `eventKey` (or stable event id), never by index. |
+| **C — Hydration** | All song routes use `useSongStateHydration(songId)`. No page-specific custom load effects. |
+| **D — Validation** | Invalid core shape fails fast with a structured message. No silent patching of bad state. |
+
+---
+
+## Commits (5)
+
+1. **fix(timeline): resolve active mapping via activeMappingId**  
+   Timeline now resolves the active mapping from `projectState.activeMappingId` (with fallback to first mapping) instead of using layout id or first mapping only.
+
+2. **refactor(event-analysis): use shared song hydration hook**  
+   Event Analysis page uses `useSongStateHydration(songId)` only; removed the local `useEffect` that called `songService.loadSongState(songId)` and added a loading state until hydration completes.
+
+3. **fix(workbench): key manual assignments by eventKey**  
+   - Workbench: `handleAssignmentChange(eventKey: string, ...)` and store `manualAssignments[layoutId][eventKey]`.  
+   - LayoutDesigner: look up by `event.eventKey ?? String(eventIndex)`.  
+   - ProjectContext: pass string-keyed `manualAssignments` to the engine (no numeric conversion).  
+   - AnalysisPanel: prop type `(eventKey: string, ...)`.  
+   - In-app project load error: replaced `alert("Failed to parse project file")` with a dismissible inline banner (message + “Use a valid project file…”).  
+   - Removed the disabled “Suggest Ergonomic Layout (Soon)” button from the settings menu.
+
+4. **feat(persistence): strict project load validation with structured errors**  
+   - `ValidationResult = { ok: true, state } | { ok: false, error: { code, message, path? } }`.  
+   - `validateProjectStrict(parsed)` rejects missing/invalid `instrumentConfig`, invalid `layouts`/`mappings`, and bad `manualAssignments` shape.  
+   - `loadProject(file)` returns `Promise<ValidationResult>`; parse errors return structured error, no throw for validation failure.  
+   - New tests: `src/utils/__tests__/projectPersistence.test.ts` (6 tests).
+
+5. **ux: remove misleading static status text**  
+   Removed the Dashboard footer text “Last Sync: 2 minutes ago”.
+
+---
+
+## Acceptance tests
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Create 2 mappings, switch in Workbench, open Timeline (same songId) | Timeline shows the selected mapping, not the first. |
+| 2 | Refresh Event Analysis with songId in URL | State matches Workbench/Timeline. |
+| 3 | Change assignment on a row (when assignment editing exists) after sorting | Only that event changes; identity is stable. |
+| 4 | Load intentionally malformed JSON (project file) | State unchanged; clear inline error; no alert. |
+| 5 | Load JSON missing `instrumentConfig` | Rejected with structured error; no silent null. |
+| 6 | Open Dashboard / Workbench settings | No “Last Sync: 2 minutes ago”; no “Suggest Ergonomic Layout (Soon)”. |
+
+---
+
+## Files touched
+
+- `src/pages/TimelinePage.tsx`
+- `src/pages/EventAnalysisPage.tsx`
+- `src/pages/Dashboard.tsx`
+- `src/workbench/Workbench.tsx`
+- `src/workbench/LayoutDesigner.tsx`
+- `src/workbench/AnalysisPanel.tsx`
+- `src/context/ProjectContext.tsx`
+- `src/types/projectState.ts`
+- `src/utils/projectPersistence.ts`
+- `src/utils/__tests__/projectPersistence.test.ts` (new)
+
+---
+
+## Guardrails respected
+
+- Changes are surgical; no broad refactors.
+- No reintroduction of legacy “engine result” state paths.
+- Single hydration path; no second mechanism.
+- Persistence load/save kept in sync with state shape.
+- Targeted tests added for strict validation.

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -1,0 +1,180 @@
+# Ableton Push 3 Performability Tool — Architecture Diagram
+
+High-level architecture: layers, data flow, and main modules.
+
+## System overview
+
+```mermaid
+flowchart TB
+  subgraph UI["UI Layer"]
+    Pages["Pages\n(Dashboard, Workbench, Timeline,\nEvent Analysis, Cost Debug)"]
+    Workbench["Workbench\n(LayoutDesigner, GridEditor,\nAnalysisPanel, Timeline)"]
+    Components["Components\n(GridVisContainer, PadLayer,\nOnionSkinGrid, ThemeToggle)"]
+  end
+
+  subgraph Context["State & Context"]
+    ProjectContext["ProjectContext\n(projectState, runSolver,\nengineResult, undo/redo)"]
+    ThemeContext["ThemeContext"]
+  end
+
+  subgraph Engine["Engine (Pure Logic)"]
+    Core["core.ts\nBiomechanicalSolver facade"]
+    Solvers["Solvers\n(Beam, Genetic, Annealing)"]
+    GridMath["gridMath\nDistance, position"]
+    Cost["costFunction\nMovement, stretch, drift"]
+    Feasibility["feasibility\nReach, grip, chord"]
+    HandPose["handPose\nNeutral positions"]
+  end
+
+  subgraph Data["Types & Data"]
+    Types["types/\nprojectState, performance,\nlayout, eventAnalysis"]
+    Utils["utils/\nperformanceSelectors,\nprojectPersistence, midiImport"]
+  end
+
+  subgraph Services["Services & Hooks"]
+    SongService["SongService"]
+    Hooks["hooks\n(useProjectHistory,\nuseSongStateHydration)"]
+  end
+
+  Pages --> ProjectContext
+  Workbench --> ProjectContext
+  Workbench --> Engine
+  Components --> Types
+  ProjectContext --> Engine
+  ProjectContext --> Types
+  ProjectContext --> Utils
+  Core --> Solvers
+  Core --> Types
+  Solvers --> GridMath
+  Solvers --> Cost
+  Solvers --> Feasibility
+  Solvers --> HandPose
+  SongService --> Types
+  Hooks --> ProjectContext
+```
+
+## Layer responsibilities
+
+| Layer | Responsibility |
+|-------|----------------|
+| **UI** | React pages and workbench; layout designer, grid editor, timeline, analysis panels. No engine logic. |
+| **Context** | Single source of truth: `ProjectState`, solver orchestration (`runSolver`), `engineResult`, history (undo/redo). |
+| **Engine** | Pure logic: solver facade, beam/genetic/annealing strategies, grid math, cost model, feasibility, hand pose. No UI. |
+| **Types** | Shared interfaces: `ProjectState`, `Performance`, `GridMapping`, `EngineResult`, etc. |
+| **Utils** | Selectors, persistence, MIDI import/export, formatting. |
+| **Services/Hooks** | Song portfolio, project history, state hydration. |
+
+## Data flow (solver run)
+
+```mermaid
+sequenceDiagram
+  participant UI as Workbench / UI
+  participant Ctx as ProjectContext
+  participant Core as BiomechanicalSolver
+  participant Solver as Beam/Genetic/Annealing
+  participant Types as types/
+
+  UI->>Ctx: runSolver(solverType, activeMapping)
+  Ctx->>Ctx: get active Performance from projectState
+  Ctx->>Core: solver.solve(performance, config)
+  Core->>Solver: strategy.solve(...)
+  Solver->>Types: reads GridMapping, InstrumentConfig
+  Solver-->>Core: EngineResult (assignments, cost, debugEvents)
+  Core-->>Ctx: EngineResult
+  Ctx->>Ctx: solverResults[solverId] = result
+  Ctx->>Ctx: setActiveSolverId(solverId)
+  Ctx-->>UI: engineResult updated → re-render grid/timeline
+```
+
+## Module dependency (simplified)
+
+```mermaid
+flowchart LR
+  subgraph NoUI["No UI imports"]
+    T["types/"]
+    E["engine/"]
+    U["utils/"]
+  end
+
+  subgraph UI["May import engine/types/utils"]
+    W["workbench/"]
+    P["pages/"]
+    C["components/"]
+  end
+
+  subgraph App["App shell"]
+    CX["context/"]
+    Main["main.tsx"]
+  end
+
+  E --> T
+  U --> T
+  W --> E
+  W --> T
+  W --> U
+  P --> W
+  P --> T
+  C --> T
+  CX --> E
+  CX --> T
+  CX --> U
+  Main --> CX
+  Main --> P
+```
+
+## Engine internals (solver strategy)
+
+```mermaid
+flowchart TB
+  subgraph Facade["core.ts (Facade)"]
+    BiomechanicalSolver["BiomechanicalSolver"]
+    resolveSolver["resolveSolver(type, config)"]
+  end
+
+  subgraph Strategies["Pluggable solvers"]
+    Beam["BeamSolver"]
+    Genetic["GeneticSolver"]
+    Annealing["AnnealingSolver"]
+  end
+
+  subgraph Shared["Shared engine modules"]
+    gridMath["gridMath"]
+    costFunction["costFunction"]
+    feasibility["feasibility"]
+    handPose["handPose"]
+    models["models (FingerType, HandState)"]
+  end
+
+  BiomechanicalSolver --> resolveSolver
+  resolveSolver --> Beam
+  resolveSolver --> Genetic
+  resolveSolver --> Annealing
+  Beam --> gridMath
+  Beam --> costFunction
+  Beam --> feasibility
+  Beam --> handPose
+  Beam --> models
+  Genetic --> gridMath
+  Genetic --> costFunction
+  Annealing --> costFunction
+```
+
+## File layout (key areas)
+
+```
+src/
+├── main.tsx              # Router, ThemeProvider, ProjectProvider
+├── context/              # ProjectContext, ThemeContext
+├── types/                # projectState, performance, layout, eventAnalysis, …
+├── engine/               # core, solvers/, gridMath, costFunction, feasibility, handPose
+├── workbench/            # Workbench, LayoutDesigner, GridEditor, AnalysisPanel, Timeline
+├── pages/                # Dashboard, TimelinePage, EventAnalysisPage, CostDebugPage
+├── components/           # ui/, grid-v3/, vis/, dashboard/
+├── utils/                # performanceSelectors, projectPersistence, midiImport, …
+├── services/             # SongService
+└── hooks/                # useProjectHistory, useSongStateHydration, usePracticeLoop
+```
+
+---
+
+*See [ARCHITECTURE.md](./ARCHITECTURE.md) for domain concepts, grid constraints, and workflow details.*

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import { ProjectState, DEFAULT_ENGINE_CONFIGURATION } from '../types/projectState';
+import { createDefaultPose0 } from '../types/naturalHandPose';
 import { InstrumentConfig } from '../types/performance';
 import { useProjectHistory } from '../hooks/useProjectHistory';
 import { EngineResult, BiomechanicalSolver, SolverType } from '../engine/core';
@@ -8,6 +9,8 @@ import { getActivePerformance } from '../utils/performanceSelectors';
 import { GridMapping, LayoutMode } from '../types/layout';
 import { createAnnealingSolver } from '../engine/solvers/AnnealingSolver';
 import { buildNeutralGreedyInitialAssignment } from '../engine/solvers/greedyInitialAssignment';
+import { getNeutralPadPositionsFromPose0 } from '../engine/handPose';
+import { poseHasAssignments } from '../types/naturalHandPose';
 
 // Initial Data
 const INITIAL_INSTRUMENT_CONFIG: InstrumentConfig = {
@@ -38,6 +41,7 @@ const INITIAL_PROJECT_STATE: ProjectState = {
     engineConfiguration: DEFAULT_ENGINE_CONFIGURATION,
     solverResults: {},
     activeSolverId: undefined,
+    naturalHandPoses: [createDefaultPose0()],
 };
 
 
@@ -157,6 +161,19 @@ export const ProjectProvider: React.FC<{ children: ReactNode }> = ({ children })
                 solverType
             );
 
+            // Apply Natural Hand Pose 0 override if available
+            const pose0 = projectState.naturalHandPoses?.[0];
+            if (pose0 && poseHasAssignments(pose0)) {
+                const neutralPadOverride = getNeutralPadPositionsFromPose0(
+                    pose0,
+                    undefined, // Auto-pick max safe offset
+                    projectState.instrumentConfig
+                );
+                if (neutralPadOverride) {
+                    solver.setNeutralPadPositionsOverride(neutralPadOverride);
+                }
+            }
+
             // Run solver (async for genetic, sync for beam). Pass string-keyed manualAssignments as-is.
             let result: EngineResult;
             if (solverType === 'genetic') {
@@ -249,10 +266,17 @@ export const ProjectProvider: React.FC<{ children: ReactNode }> = ({ children })
                 : undefined;
 
         try {
-            // Create AnnealingSolver
+            // Apply Natural Hand Pose 0 to Auto-Arrange so layouts are attracted to pose pads
+            const pose0 = projectState.naturalHandPoses?.[0];
+            const neutralPadOverride = (pose0 && poseHasAssignments(pose0))
+                ? getNeutralPadPositionsFromPose0(pose0, undefined, projectState.instrumentConfig)
+                : null;
+
+            // Create AnnealingSolver (with Pose 0 override when available)
             const solver = createAnnealingSolver({
                 instrumentConfig: projectState.instrumentConfig,
                 gridMapping: mapping,
+                neutralPadPositionsOverride: neutralPadOverride ?? undefined,
             });
 
             // Run the solver (pass string-keyed manualAssignments as-is)

--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -3,8 +3,13 @@
  */
 
 /**
- * Default test MIDI file URL for automatic loading during development.
- * This file is automatically loaded if no MIDI performance is present.
+ * Default test MIDI file URL (served from public folder).
+ * Used as the hardcoded default test clip on the portfolio page.
  */
-export const DEFAULT_TEST_MIDI_URL = 'TEST MIDI 1.mid';
+export const DEFAULT_TEST_MIDI_URL = '/default-test.mid';
+
+/**
+ * Fixed ID for the default test song. Seeded on first load so users don't need to import.
+ */
+export const DEFAULT_TEST_SONG_ID = 'default-test';
 

--- a/src/engine/core.ts
+++ b/src/engine/core.ts
@@ -14,6 +14,7 @@ import { InstrumentConfig } from '../types/performance';
 import { GridMapping } from '../types/layout';
 import { FingerType, EngineConstants, DEFAULT_ENGINE_CONSTANTS } from './models';
 import { DEFAULT_ENGINE_CONFIGURATION } from '../types/projectState';
+import { NeutralPadPositions } from './handPose';
 
 // Re-export types from solvers for backwards compatibility
 export type {
@@ -91,6 +92,7 @@ export class BiomechanicalSolver {
   private gridMapping: GridMapping | null;
   private engineConfig: EngineConfiguration;
   private strategy: SolverStrategy;
+  private neutralPadPositionsOverride: NeutralPadPositions | null = null;
 
   constructor(
     instrumentConfig: InstrumentConfig,
@@ -136,6 +138,7 @@ export class BiomechanicalSolver {
     const solverConfig: SolverConfig = {
       instrumentConfig: this.instrumentConfig,
       gridMapping: this.gridMapping,
+      neutralPadPositionsOverride: this.neutralPadPositionsOverride,
     };
 
     this.strategy = resolveSolver(type, solverConfig);
@@ -152,9 +155,31 @@ export class BiomechanicalSolver {
     const solverConfig: SolverConfig = {
       instrumentConfig: this.instrumentConfig,
       gridMapping: this.gridMapping,
+      neutralPadPositionsOverride: this.neutralPadPositionsOverride,
     };
 
     // Recreate strategy with new config
+    this.strategy = resolveSolver(this.strategy.type, solverConfig);
+  }
+
+  /**
+   * Sets the neutral pad positions override from Natural Hand Pose 0.
+   * 
+   * When set, the solver uses these per-finger positions instead of
+   * the default musical-note-based positions for computing hand centers.
+   * 
+   * @param override - NeutralPadPositions from Pose 0, or null to clear
+   */
+  public setNeutralPadPositionsOverride(override: NeutralPadPositions | null): void {
+    this.neutralPadPositionsOverride = override;
+
+    // Recreate strategy with updated config
+    const solverConfig: SolverConfig = {
+      instrumentConfig: this.instrumentConfig,
+      gridMapping: this.gridMapping,
+      neutralPadPositionsOverride: this.neutralPadPositionsOverride,
+    };
+
     this.strategy = resolveSolver(this.strategy.type, solverConfig);
   }
 

--- a/src/engine/costFunction.ts
+++ b/src/engine/costFunction.ts
@@ -585,6 +585,43 @@ export function calculateAttractorCost(
 }
 
 /**
+ * Per-finger home cost: penalizes each finger's distance from its neutral pad.
+ * Used when Natural Hand Pose 0 override is present to strongly favor pose positions.
+ * Finger at neutral pad = 0 cost; cost increases with distance.
+ *
+ * @param pose - Current hand pose (finger positions)
+ * @param handSide - Which hand
+ * @param neutralHandCenters - Neutral pad positions (from Pose 0)
+ * @param weight - Cost weight per unit distance (default 0.8)
+ */
+export function calculatePerFingerHomeCost(
+  pose: HandPose,
+  handSide: 'left' | 'right',
+  neutralHandCenters: NeutralHandCenters,
+  weight: number = 0.8
+): number {
+  let total = 0;
+  const prefix = handSide === 'left' ? 'L' : 'R';
+  const fingerNums: Record<FingerType, number> = {
+    thumb: 1,
+    index: 2,
+    middle: 3,
+    ring: 4,
+    pinky: 5,
+  };
+
+  for (const [finger, coord] of Object.entries(pose.fingers) as [FingerType, FingerCoordinate][]) {
+    const key = `${prefix}${fingerNums[finger]}`;
+    const neutral = neutralHandCenters.neutralPads[key];
+    if (!neutral) continue;
+    const dist = fingerCoordinateDistance(coord, { x: neutral.col, y: neutral.row });
+    total += dist * weight;
+  }
+
+  return total;
+}
+
+/**
  * Calculates the transition cost for moving from one hand pose to another.
  * 
  * Implements Fitts's Law principles:

--- a/src/engine/handPose.ts
+++ b/src/engine/handPose.ts
@@ -10,8 +10,16 @@
  */
 
 import { GridMapping, cellKey } from '../types/layout';
-import { InstrumentConfig } from '../types/performance';
+import { InstrumentConfig, RestingPose, HandPose, FingerCoordinate } from '../types/performance';
 import { GridMapService } from './gridMapService';
+import { FingerType } from './models';
+import {
+  NaturalHandPose,
+  fingerIdToEngineKey,
+  getPose0PadsWithOffset,
+  getMaxSafeOffset,
+  poseHasAssignments,
+} from '../types/naturalHandPose';
 
 // ============================================================================
 // Core Types
@@ -212,6 +220,71 @@ export function resolveNeutralPadPositions(
   return result;
 }
 
+/**
+ * Converts a Natural Hand Pose (Pose 0) to NeutralPadPositions format.
+ * 
+ * This allows the solver to use user-defined finger positions instead of
+ * the default musical-note-based positions.
+ * 
+ * @param pose - The Natural Hand Pose configuration
+ * @param offsetRow - Vertical offset to apply (signed, [-4, +4]). If not provided, uses max safe offset.
+ * @param instrumentConfig - Instrument configuration for deriving note numbers
+ * @returns NeutralPadPositions or null if pose has no assignments
+ */
+export function getNeutralPadPositionsFromPose0(
+  pose: NaturalHandPose,
+  offsetRow?: number,
+  instrumentConfig?: InstrumentConfig
+): NeutralPadPositions | null {
+  if (!poseHasAssignments(pose)) {
+    return null;
+  }
+
+  // Use provided offset or calculate max safe offset
+  const effectiveOffset = offsetRow ?? getMaxSafeOffset(pose, true);
+  
+  // Get pads with offset applied (clamped to grid)
+  const padsWithOffset = getPose0PadsWithOffset(pose, effectiveOffset, true);
+  
+  const result: NeutralPadPositions = {};
+  
+  for (const { fingerId, row, col } of padsWithOffset) {
+    // Convert FingerId to engine key (e.g., "L_INDEX" -> "L2")
+    const engineKey = fingerIdToEngineKey(fingerId);
+    const padId = cellKey(row, col);
+    
+    // Calculate MIDI note number if instrument config is provided
+    let noteNumber = 0;
+    let noteName = '';
+    if (instrumentConfig) {
+      noteNumber = GridMapService.getNoteForPosition(row, col, instrumentConfig) ?? 0;
+      noteName = midiToNoteName(noteNumber);
+    }
+    
+    result[engineKey] = {
+      row,
+      col,
+      padId,
+      noteNumber,
+      noteName,
+    };
+  }
+  
+  return result;
+}
+
+/**
+ * Converts a MIDI note number to a note name string.
+ * @param midiNote - MIDI note number (0-127)
+ * @returns Note name in format "C0", "D#2", etc.
+ */
+function midiToNoteName(midiNote: number): string {
+  const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const note = NOTE_NAMES[midiNote % 12];
+  const octave = Math.floor(midiNote / 12) - 2;
+  return `${note}${octave}`;
+}
+
 // ============================================================================
 // Neutral Hand Centers
 // ============================================================================
@@ -277,6 +350,61 @@ export function computeNeutralHandCenters(
     leftCenter,
     rightCenter,
     neutralPads,
+  };
+}
+
+/** Engine key (L1..R5) to FingerType for building HandPose.fingers */
+const ENGINE_KEY_TO_FINGER: Record<string, FingerType> = {
+  L1: 'thumb', L2: 'index', L3: 'middle', L4: 'ring', L5: 'pinky',
+  R1: 'thumb', R2: 'index', R3: 'middle', R4: 'ring', R5: 'pinky',
+};
+
+/**
+ * Builds a RestingPose from NeutralPadPositions (e.g. from Pose 0).
+ * Used so the attractor cost in the solver pulls toward the user's natural hand pose
+ * instead of the default claw.
+ *
+ * @param neutralPads - Per-finger pad positions (L1..R5)
+ * @returns RestingPose with left/right HandPose (centroid + fingers), or null if empty
+ */
+export function restingPoseFromNeutralPadPositions(
+  neutralPads: NeutralPadPositions
+): RestingPose | null {
+  const leftFingers: Partial<Record<FingerType, FingerCoordinate>> = {};
+  const rightFingers: Partial<Record<FingerType, FingerCoordinate>> = {};
+  let leftSumX = 0, leftSumY = 0, leftCount = 0;
+  let rightSumX = 0, rightSumY = 0, rightCount = 0;
+
+  for (const [key, pos] of Object.entries(neutralPads)) {
+    const finger = ENGINE_KEY_TO_FINGER[key];
+    if (!finger) continue;
+    const coord: FingerCoordinate = { x: pos.col, y: pos.row };
+    if (key.startsWith('L')) {
+      leftFingers[finger] = coord;
+      leftSumX += pos.col;
+      leftSumY += pos.row;
+      leftCount++;
+    } else {
+      rightFingers[finger] = coord;
+      rightSumX += pos.col;
+      rightSumY += pos.row;
+      rightCount++;
+    }
+  }
+
+  const leftCenter: FingerCoordinate = leftCount > 0
+    ? { x: leftSumX / leftCount, y: leftSumY / leftCount }
+    : { x: 2, y: 2 };
+  const rightCenter: FingerCoordinate = rightCount > 0
+    ? { x: rightSumX / rightCount, y: rightSumY / rightCount }
+    : { x: 5, y: 2 };
+
+  const leftPose: HandPose = { centroid: leftCenter, fingers: leftFingers };
+  const rightPose: HandPose = { centroid: rightCenter, fingers: rightFingers };
+
+  return {
+    left: leftPose,
+    right: rightPose,
   };
 }
 

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -43,7 +43,7 @@ export { DEFAULT_ENGINE_CONSTANTS } from './models';
 
 // Hand pose configuration
 export type { Hand, FingerId, NeutralFingerPose, NeutralHandPose, NeutralPadPosition, NeutralPadPositions, NeutralHandCenters } from './handPose';
-export { DEFAULT_HAND_POSE, resolveNeutralPadPositions, getNeutralHandCenters, computeNeutralHandCenters } from './handPose';
+export { DEFAULT_HAND_POSE, resolveNeutralPadPositions, getNeutralPadPositionsFromPose0, getNeutralHandCenters, computeNeutralHandCenters } from './handPose';
 
 // Feasibility checking
 export { 

--- a/src/engine/solvers/AnnealingSolver.ts
+++ b/src/engine/solvers/AnnealingSolver.ts
@@ -11,6 +11,7 @@ import { GridMapping } from '../../types/layout';
 import { FingerType } from '../models';
 import { createBeamSolver } from './BeamSolver';
 import { applyRandomMutation } from './mutationService';
+import { NeutralPadPositions } from '../handPose';
 import {
   SolverStrategy,
   SolverType,
@@ -84,11 +85,13 @@ export class AnnealingSolver implements SolverStrategy {
 
   private instrumentConfig: SolverConfig['instrumentConfig'];
   private initialGridMapping: GridMapping | null;
+  private neutralPadPositionsOverride: NeutralPadPositions | null = null;
   private bestMapping: GridMapping | null = null;
 
   constructor(config: SolverConfig) {
     this.instrumentConfig = config.instrumentConfig;
     this.initialGridMapping = config.gridMapping ?? null;
+    this.neutralPadPositionsOverride = config.neutralPadPositionsOverride ?? null;
   }
 
   /**
@@ -114,10 +117,11 @@ export class AnnealingSolver implements SolverStrategy {
     config: EngineConfiguration,
     beamWidth: number
   ): Promise<{ result: EngineResult; cost: number }> {
-    // Create a BeamSolver with the candidate mapping
+    // Create a BeamSolver with the candidate mapping (include Pose 0 override when present)
     const solverConfig: SolverConfig = {
       instrumentConfig: this.instrumentConfig,
       gridMapping: mapping,
+      neutralPadPositionsOverride: this.neutralPadPositionsOverride,
     };
 
     const beamSolver = createBeamSolver(solverConfig);

--- a/src/engine/solvers/BeamSolver.ts
+++ b/src/engine/solvers/BeamSolver.ts
@@ -16,10 +16,11 @@ import {
   calculateAttractorCost,
   calculateTransitionCost,
   calculateGripStretchCost,
+  calculatePerFingerHomeCost,
   FALLBACK_GRIP_PENALTY,
 } from '../costFunction';
 import { GridPosition } from '../gridMath';
-import { getNeutralHandCenters, NeutralHandCenters } from '../handPose';
+import { getNeutralHandCenters, computeNeutralHandCenters, restingPoseFromNeutralPadPositions, NeutralHandCenters, NeutralPadPositions } from '../handPose';
 import {
   SolverStrategy,
   SolverType,
@@ -170,10 +171,12 @@ export class BeamSolver implements SolverStrategy {
 
   private instrumentConfig: InstrumentConfig;
   private gridMapping: GridMapping | null;
+  private neutralPadPositionsOverride: NeutralPadPositions | null;
 
   constructor(config: SolverConfig) {
     this.instrumentConfig = config.instrumentConfig;
     this.gridMapping = config.gridMapping ?? null;
+    this.neutralPadPositionsOverride = config.neutralPadPositionsOverride ?? null;
   }
 
   /**
@@ -274,11 +277,14 @@ export class BeamSolver implements SolverStrategy {
 
         const attractorCost = calculateAttractorCost(grip, restPose, stiffness);
         const staticCost = calculateGripStretchCost(grip, hand, undefined, undefined, neutralHandCenters);
+        const perFingerHomeCost = neutralHandCenters
+          ? calculatePerFingerHomeCost(grip, hand, neutralHandCenters, 0.8)
+          : 0;
 
         // Apply fallback penalty if this is a fallback grip
         const fallbackPenalty = isFallback ? FALLBACK_GRIP_PENALTY : 0;
 
-        const stepCost = effectiveTransitionCost + attractorCost + staticCost + fallbackPenalty;
+        const stepCost = effectiveTransitionCost + attractorCost + staticCost + perFingerHomeCost + fallbackPenalty;
         const newTotalCost = node.totalCost + stepCost;
 
         // Get fingers from grip for assignment
@@ -405,6 +411,8 @@ export class BeamSolver implements SolverStrategy {
         const rightAttractor = calculateAttractorCost(rightResult.pose, restingPose.right, stiffness);
         const leftStatic = calculateGripStretchCost(leftResult.pose, 'left', undefined, undefined, neutralHandCenters);
         const rightStatic = calculateGripStretchCost(rightResult.pose, 'right', undefined, undefined, neutralHandCenters);
+        const leftHome = neutralHandCenters ? calculatePerFingerHomeCost(leftResult.pose, 'left', neutralHandCenters, 0.8) : 0;
+        const rightHome = neutralHandCenters ? calculatePerFingerHomeCost(rightResult.pose, 'right', neutralHandCenters, 0.8) : 0;
 
         // Apply fallback penalties
         const leftFallbackPenalty = leftResult.isFallback ? FALLBACK_GRIP_PENALTY : 0;
@@ -413,6 +421,7 @@ export class BeamSolver implements SolverStrategy {
         const stepCost = effectiveLeftTransition + effectiveRightTransition +
           leftAttractor + rightAttractor +
           leftStatic + rightStatic +
+          leftHome + rightHome +
           leftFallbackPenalty + rightFallbackPenalty;
 
         // Create assignments for ALL notes in the split chord (1:1 finger per note per hand)
@@ -597,7 +606,7 @@ export class BeamSolver implements SolverStrategy {
       const fingerKey = `${assignment.hand === 'left' ? 'L' : 'R'}-${assignment.finger.charAt(0).toUpperCase() + assignment.finger.slice(1)}`;
       fingerUsageStats[fingerKey] = (fingerUsageStats[fingerKey] || 0) + 1;
 
-      // Calculate drift from home
+      // Calculate drift from home (config is effectiveConfig when Pose 0 override is present)
       const { restingPose } = config;
       const homeCentroid = assignment.hand === 'left'
         ? restingPose.left.centroid
@@ -721,16 +730,40 @@ export class BeamSolver implements SolverStrategy {
     config: EngineConfiguration,
     manualAssignments?: Record<string, { hand: 'left' | 'right', finger: FingerType }>
   ): EngineResult {
-    // Compute neutral hand centers from the current layout
+    // Compute neutral hand centers from Pose 0 override or the current layout
     let neutralHandCenters: NeutralHandCenters | null = null;
-    if (this.gridMapping) {
+    if (this.neutralPadPositionsOverride) {
+      // Use Natural Hand Pose 0 override - derive centers from per-finger positions
+      try {
+        neutralHandCenters = computeNeutralHandCenters(this.neutralPadPositionsOverride);
+      } catch (error) {
+        console.warn('[BeamSolver] Failed to compute neutral hand centers from Pose 0 override:', error);
+        // Fall back to layout-based centers
+      }
+    }
+    
+    // Fall back to layout-based neutral centers if override not available or failed
+    if (!neutralHandCenters && this.gridMapping) {
       try {
         neutralHandCenters = getNeutralHandCenters(this.gridMapping, this.instrumentConfig);
       } catch (error) {
-        console.warn('[BeamSolver] Failed to compute neutral hand centers:', error);
+        console.warn('[BeamSolver] Failed to compute neutral hand centers from layout:', error);
         // Continue without neutral centers (graceful degradation)
       }
     }
+
+    // When Pose 0 override is present, use it as the attractor resting pose and strengthen the attractor
+    const effectiveRestingPose = this.neutralPadPositionsOverride
+      ? (restingPoseFromNeutralPadPositions(this.neutralPadPositionsOverride) ?? config.restingPose)
+      : config.restingPose;
+    const effectiveStiffness = this.neutralPadPositionsOverride
+      ? Math.min(2.0, config.stiffness * 2.0)
+      : config.stiffness;
+    const effectiveConfig: EngineConfiguration = {
+      ...config,
+      restingPose: effectiveRestingPose,
+      stiffness: effectiveStiffness,
+    };
 
     // Sort events by time
     const sortedEvents = [...performance.events]
@@ -753,8 +786,8 @@ export class BeamSolver implements SolverStrategy {
     // Group events by timestamp (handles chords correctly)
     const groups = groupEventsByTimestamp(eventsWithPositions);
 
-    // Initialize beam with resting pose
-    let beam = this.createInitialBeam(config);
+    // Initialize beam with resting pose (uses Pose 0 when override present)
+    let beam = this.createInitialBeam(effectiveConfig);
     let prevTimestamp = 0;
 
     // Process each group (single notes and chords treated uniformly)
@@ -793,15 +826,18 @@ export class BeamSolver implements SolverStrategy {
               const timeDelta = group.timestamp - prevTimestamp;
               const prevPose = override.hand === 'left' ? node.leftPose : node.rightPose;
               const restPose = override.hand === 'left'
-                ? config.restingPose.left
-                : config.restingPose.right;
+                ? effectiveConfig.restingPose.left
+                : effectiveConfig.restingPose.right;
 
               const transitionCost = calculateTransitionCost(prevPose, matchingResult.pose, timeDelta);
-              const attractorCost = calculateAttractorCost(matchingResult.pose, restPose, config.stiffness);
+              const attractorCost = calculateAttractorCost(matchingResult.pose, restPose, effectiveConfig.stiffness);
               const staticCost = calculateGripStretchCost(matchingResult.pose, override.hand, undefined, undefined, neutralHandCenters);
+              const perFingerHomeCost = neutralHandCenters
+                ? calculatePerFingerHomeCost(matchingResult.pose, override.hand, neutralHandCenters, 0.8)
+                : 0;
               const fallbackPenalty = matchingResult.isFallback ? FALLBACK_GRIP_PENALTY : 0;
               const effectiveTransition = transitionCost === Infinity ? 100 : transitionCost;
-              const stepCost = effectiveTransition + attractorCost + staticCost + fallbackPenalty;
+              const stepCost = effectiveTransition + attractorCost + staticCost + perFingerHomeCost + fallbackPenalty;
 
               // Create assignments for ALL notes in the group (handles chords)
               const assignments: NoteAssignment[] = [];
@@ -837,7 +873,7 @@ export class BeamSolver implements SolverStrategy {
         }
 
         // Standard expansion using group-based approach
-        const children = this.expandNodeForGroup(node, group, prevTimestamp, config, neutralHandCenters);
+        const children = this.expandNodeForGroup(node, group, prevTimestamp, effectiveConfig, neutralHandCenters);
         newBeam.push(...children);
 
         // For multi-note chords, also try split-hand approach
@@ -928,13 +964,13 @@ export class BeamSolver implements SolverStrategy {
       }
 
       // Prune beam to keep top K candidates
-      beam = this.pruneBeam(newBeam, config.beamWidth);
+      beam = this.pruneBeam(newBeam, effectiveConfig.beamWidth);
       prevTimestamp = group.timestamp;
     }
 
     // Find best node (lowest total cost)
     if (beam.length === 0) {
-      return this.buildResult([], performance.events.length, unmappedIndices, config);
+      return this.buildResult([], performance.events.length, unmappedIndices, effectiveConfig);
     }
 
     const bestNode = beam.reduce((best, node) =>
@@ -944,7 +980,7 @@ export class BeamSolver implements SolverStrategy {
     // Backtrack to build optimal assignment path
     const assignments = this.backtrack(bestNode);
 
-    return this.buildResult(assignments, performance.events.length, unmappedIndices, config);
+    return this.buildResult(assignments, performance.events.length, unmappedIndices, effectiveConfig);
   }
 }
 

--- a/src/engine/solvers/types.ts
+++ b/src/engine/solvers/types.ts
@@ -10,6 +10,7 @@ import { Performance, EngineConfiguration } from '../../types/performance';
 import { InstrumentConfig } from '../../types/performance';
 import { GridMapping } from '../../types/layout';
 import { FingerType, EngineConstants } from '../models';
+import { NeutralPadPositions } from '../handPose';
 
 // ============================================================================
 // Solver Result Types (shared across all solvers)
@@ -247,6 +248,13 @@ export interface SolverConfig {
   gridMapping?: GridMapping | null;
   /** Optional engine constants (deprecated, kept for compatibility) */
   engineConstants?: EngineConstants;
+  /**
+   * Optional override for neutral pad positions.
+   * When provided (e.g., from Natural Hand Pose 0), the solver uses these positions
+   * instead of the default musical-note-based positions.
+   * Solver derives neutral hand centers from these positions via computeNeutralHandCenters.
+   */
+  neutralPadPositionsOverride?: NeutralPadPositions | null;
 }
 
 /**

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,13 +24,8 @@ export const Dashboard: React.FC = () => {
     };
 
     useEffect(() => {
-        // Seed mock data for MVP if empty
-        // Seed mock data removed for production readiness - starts empty
-        // songService.seedMockData();
-        // Load songs
-        refreshSongs();
-
-
+        // Seed default test MIDI clip if not already present (hardcoded, no import needed)
+        songService.seedDefaultTestSong().then(() => refreshSongs());
     }, []);
 
 

--- a/src/services/SongService.ts
+++ b/src/services/SongService.ts
@@ -6,7 +6,9 @@ const STORAGE_KEY = 'push_perf_songs';
 import { parseMidiFileToProject, MidiProjectData } from '../utils/midiImport';
 import { saveProjectStateToStorage, loadProjectStateFromStorage, deleteProjectStateFromStorage } from '../utils/projectPersistence';
 import { ProjectState } from '../types/projectState';
+import { createDefaultPose0 } from '../types/naturalHandPose';
 import { generateId } from '../utils/performanceUtils';
+import { DEFAULT_TEST_MIDI_URL, DEFAULT_TEST_SONG_ID } from '../data/testData';
 
 class SongService {
     private getSongsMap(): Record<string, Song> {
@@ -118,6 +120,7 @@ class SongService {
             mappings: [gridMappingWithMode], // Empty grid with layoutMode: 'none'
             ignoredNoteNumbers: [],
             manualAssignments: {},
+            naturalHandPoses: [createDefaultPose0()],
         };
 
         return state;
@@ -315,6 +318,70 @@ class SongService {
     seedMockData(): void {
         // Mock data removed to ensure only valid MIDI data is used.
         // User must import Songs from MIDI files.
+    }
+
+    /**
+     * Seeds the default test song (TEST MIDI 1) if it doesn't exist.
+     * The MIDI is bundled in public/default-test.mid - no import needed.
+     */
+    async seedDefaultTestSong(): Promise<void> {
+        const existing = this.getSong(DEFAULT_TEST_SONG_ID);
+        if (existing?.midiData) {
+            return; // Already seeded
+        }
+
+        try {
+            const res = await fetch(DEFAULT_TEST_MIDI_URL);
+            if (!res.ok) throw new Error(`Failed to fetch default test MIDI: ${res.status}`);
+            const arrayBuffer = await res.arrayBuffer();
+
+            const projectData = await parseMidiFileToProject(
+                new File([arrayBuffer], 'default-test.mid', { type: 'audio/midi' })
+            );
+            const { performance, minNoteNumber } = projectData;
+
+            const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+            const rootNote = minNoteNumber != null ? noteNames[minNoteNumber % 12] : 'C';
+            const inferredKey = `${rootNote} Major`;
+
+            const lastEvent = performance.events[performance.events.length - 1];
+            const duration = lastEvent ? Math.ceil(lastEvent.startTime + (lastEvent.duration || 0)) : 0;
+
+            const projectStateId = uuidv4();
+            const initialState = this.createProjectStateFromMidi(projectData);
+            saveProjectStateToStorage(projectStateId, initialState);
+
+            const base64 = btoa(
+                String.fromCharCode(...new Uint8Array(arrayBuffer))
+            );
+
+            const newSong: Song = {
+                metadata: {
+                    id: DEFAULT_TEST_SONG_ID,
+                    title: 'Default Test (Scenario 1)',
+                    artist: 'Built-in',
+                    bpm: performance.tempo || 120,
+                    key: inferredKey,
+                    duration,
+                    lastPracticed: Date.now(),
+                    totalPracticeTime: 0,
+                    performanceRating: 0,
+                    difficulty: 'Medium',
+                    isFavorite: false,
+                    tags: ['Default', 'Test'],
+                },
+                sections: [],
+                projectStateId,
+                midiData: base64,
+                midiFileName: 'TEST MIDI 1.mid',
+            };
+
+            const songs = this.getSongsMap();
+            songs[DEFAULT_TEST_SONG_ID] = newSong;
+            this.saveSongsMap(songs);
+        } catch (err) {
+            console.warn('[SongService] Could not seed default test song:', err);
+        }
     }
 }
 

--- a/src/types/__tests__/naturalHandPose.test.ts
+++ b/src/types/__tests__/naturalHandPose.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Unit tests for Natural Hand Pose types and utilities
+ * 
+ * Test checklist from plan:
+ * - normalizePose0: Given pads with minRow > 0, stored rows start at 0
+ * - getPose0PadsWithOffset: Offsets behave correctly (signed, clamped)
+ * - getMaxSafeOffset: Returns largest safe offset in [-4, +4]
+ * - validateNaturalHandPose: Catches duplicate pads, invalid coords
+ * - Import → normalize: Stable representation after import
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  NaturalHandPose,
+  FingerId,
+  PadCoord,
+  createDefaultPose0,
+  createEmptyPose0,
+  normalizePose0,
+  validateNaturalHandPose,
+  getPose0PadsWithOffset,
+  getMaxSafeOffset,
+  isOffsetSafe,
+  fingerIdToEngineKey,
+  engineKeyToFingerId,
+  poseHasAssignments,
+  getAssignedFingerCount,
+} from '../naturalHandPose';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createPoseWithPads(pads: Partial<Record<FingerId, PadCoord | null>>): NaturalHandPose {
+  const base = createEmptyPose0();
+  return {
+    ...base,
+    fingerToPad: {
+      ...base.fingerToPad,
+      ...pads,
+    },
+  };
+}
+
+// ============================================================================
+// Tests: normalizePose0
+// ============================================================================
+
+describe('normalizePose0', () => {
+  it('should normalize pose so minRow becomes 0', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 3, col: 2 },
+      L_MIDDLE: { row: 4, col: 3 },
+      R_INDEX: { row: 5, col: 5 },
+    });
+
+    const normalized = normalizePose0(pose);
+
+    // minRow was 3, so all rows should be shifted by -3
+    expect(normalized.fingerToPad.L_INDEX).toEqual({ row: 0, col: 2 });
+    expect(normalized.fingerToPad.L_MIDDLE).toEqual({ row: 1, col: 3 });
+    expect(normalized.fingerToPad.R_INDEX).toEqual({ row: 2, col: 5 });
+  });
+
+  it('should preserve column values during normalization', () => {
+    const pose = createPoseWithPads({
+      L_THUMB: { row: 2, col: 0 },
+      R_PINKY: { row: 2, col: 7 },
+    });
+
+    const normalized = normalizePose0(pose);
+
+    expect(normalized.fingerToPad.L_THUMB?.col).toBe(0);
+    expect(normalized.fingerToPad.R_PINKY?.col).toBe(7);
+  });
+
+  it('should handle pose already at row 0', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      L_MIDDLE: { row: 1, col: 3 },
+    });
+
+    const normalized = normalizePose0(pose);
+
+    expect(normalized.fingerToPad.L_INDEX).toEqual({ row: 0, col: 2 });
+    expect(normalized.fingerToPad.L_MIDDLE).toEqual({ row: 1, col: 3 });
+  });
+
+  it('should handle empty pose (no assignments)', () => {
+    const pose = createEmptyPose0();
+    const normalized = normalizePose0(pose);
+
+    // Should not throw, all fingers should remain null
+    for (const fingerId of Object.keys(normalized.fingerToPad) as FingerId[]) {
+      expect(normalized.fingerToPad[fingerId]).toBeNull();
+    }
+  });
+
+  it('should set a valid updatedAt timestamp', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 3, col: 2 },
+    });
+
+    const normalized = normalizePose0(pose);
+
+    // Should be a valid ISO timestamp
+    expect(typeof normalized.updatedAt).toBe('string');
+    expect(new Date(normalized.updatedAt).getTime()).not.toBeNaN();
+  });
+});
+
+// ============================================================================
+// Tests: getPose0PadsWithOffset
+// ============================================================================
+
+describe('getPose0PadsWithOffset', () => {
+  it('should return pads unchanged with offset 0', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      R_INDEX: { row: 2, col: 5 },
+    });
+
+    const pads = getPose0PadsWithOffset(pose, 0);
+
+    expect(pads).toHaveLength(2);
+    expect(pads.find(p => p.fingerId === 'L_INDEX')).toEqual({
+      fingerId: 'L_INDEX',
+      row: 0,
+      col: 2,
+    });
+    expect(pads.find(p => p.fingerId === 'R_INDEX')).toEqual({
+      fingerId: 'R_INDEX',
+      row: 2,
+      col: 5,
+    });
+  });
+
+  it('should apply positive offset (shift up)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      L_MIDDLE: { row: 1, col: 3 },
+    });
+
+    const pads = getPose0PadsWithOffset(pose, 3);
+
+    expect(pads.find(p => p.fingerId === 'L_INDEX')?.row).toBe(3);
+    expect(pads.find(p => p.fingerId === 'L_MIDDLE')?.row).toBe(4);
+  });
+
+  it('should apply negative offset (shift down)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 4, col: 2 },
+      L_MIDDLE: { row: 5, col: 3 },
+    });
+
+    const pads = getPose0PadsWithOffset(pose, -2);
+
+    expect(pads.find(p => p.fingerId === 'L_INDEX')?.row).toBe(2);
+    expect(pads.find(p => p.fingerId === 'L_MIDDLE')?.row).toBe(3);
+  });
+
+  it('should allow off-grid rows when clamp=false', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+    });
+
+    const pads = getPose0PadsWithOffset(pose, -2, false);
+
+    expect(pads[0].row).toBe(-2); // Off-grid, but allowed
+  });
+
+  it('should clamp rows to [0,7] when clamp=true', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      R_INDEX: { row: 6, col: 5 },
+    });
+
+    // Offset -3 would put L_INDEX at -3
+    const padsDown = getPose0PadsWithOffset(pose, -3, true);
+    expect(padsDown.find(p => p.fingerId === 'L_INDEX')?.row).toBe(0); // Clamped to 0
+
+    // Offset +3 would put R_INDEX at 9
+    const padsUp = getPose0PadsWithOffset(pose, 3, true);
+    expect(padsUp.find(p => p.fingerId === 'R_INDEX')?.row).toBe(7); // Clamped to 7
+  });
+
+  it('should preserve column values', () => {
+    const pose = createPoseWithPads({
+      L_THUMB: { row: 0, col: 0 },
+      R_PINKY: { row: 0, col: 7 },
+    });
+
+    const pads = getPose0PadsWithOffset(pose, 4);
+
+    expect(pads.find(p => p.fingerId === 'L_THUMB')?.col).toBe(0);
+    expect(pads.find(p => p.fingerId === 'R_PINKY')?.col).toBe(7);
+  });
+
+  it('should skip null assignments', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      // All others are null
+    });
+
+    const pads = getPose0PadsWithOffset(pose, 0);
+
+    expect(pads).toHaveLength(1);
+    expect(pads[0].fingerId).toBe('L_INDEX');
+  });
+});
+
+// ============================================================================
+// Tests: getMaxSafeOffset
+// ============================================================================
+
+describe('getMaxSafeOffset', () => {
+  it('should return 0 for empty pose', () => {
+    const pose = createEmptyPose0();
+    expect(getMaxSafeOffset(pose)).toBe(0);
+  });
+
+  it('should return max positive offset when preferPositive=true', () => {
+    // Pose at rows 0-2, max safe positive offset is 7-2=5, clamped to 4
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      L_MIDDLE: { row: 1, col: 3 },
+      L_RING: { row: 2, col: 4 },
+    });
+
+    const offset = getMaxSafeOffset(pose, true);
+
+    expect(offset).toBe(4); // Clamped to max of 4
+  });
+
+  it('should return max negative offset when preferPositive=false', () => {
+    // Pose at rows 3-5, max safe negative offset is -3
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 3, col: 2 },
+      L_MIDDLE: { row: 4, col: 3 },
+      L_RING: { row: 5, col: 4 },
+    });
+
+    const offset = getMaxSafeOffset(pose, false);
+
+    expect(offset).toBe(-3);
+  });
+
+  it('should respect [-4, +4] bounds', () => {
+    // Pose spans rows 0-7, so only offset 0 is safe
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 0, col: 2 },
+      R_INDEX: { row: 7, col: 5 },
+    });
+
+    expect(getMaxSafeOffset(pose, true)).toEqual(0);
+    expect(getMaxSafeOffset(pose, false)).toEqual(0);
+  });
+
+  it('should calculate correct offset for normalized pose', () => {
+    // Normalized pose at rows 0-3, can shift up by 4 (7-3=4)
+    const pose = createPoseWithPads({
+      L_THUMB: { row: 0, col: 1 },
+      L_INDEX: { row: 1, col: 2 },
+      L_MIDDLE: { row: 2, col: 3 },
+      L_RING: { row: 3, col: 4 },
+    });
+
+    expect(getMaxSafeOffset(pose, true)).toBe(4);
+    expect(getMaxSafeOffset(pose, false)).toEqual(0); // Can't go lower than 0
+  });
+});
+
+// ============================================================================
+// Tests: isOffsetSafe
+// ============================================================================
+
+describe('isOffsetSafe', () => {
+  it('should return true for offset 0', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 3, col: 2 },
+    });
+
+    expect(isOffsetSafe(pose, 0)).toBe(true);
+  });
+
+  it('should return false when offset pushes finger below 0', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 2 },
+    });
+
+    expect(isOffsetSafe(pose, -3)).toBe(false); // Would put row at -1
+  });
+
+  it('should return false when offset pushes finger above 7', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 5, col: 2 },
+    });
+
+    expect(isOffsetSafe(pose, 3)).toBe(false); // Would put row at 8
+  });
+
+  it('should return true for empty pose with any offset', () => {
+    const pose = createEmptyPose0();
+
+    expect(isOffsetSafe(pose, -4)).toBe(true);
+    expect(isOffsetSafe(pose, 4)).toBe(true);
+  });
+});
+
+// ============================================================================
+// Tests: validateNaturalHandPose
+// ============================================================================
+
+describe('validateNaturalHandPose', () => {
+  it('should validate a correct pose', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 3 },
+      R_INDEX: { row: 2, col: 5 },
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should reject duplicate pad assignments', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 3 },
+      R_INDEX: { row: 2, col: 3 }, // Same pad!
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Duplicate pad');
+    expect(result.error).toContain('L_INDEX');
+    expect(result.error).toContain('R_INDEX');
+  });
+
+  it('should reject row out of range (< 0)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: -1, col: 3 },
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('row');
+    expect(result.error).toContain('out of range');
+  });
+
+  it('should reject row out of range (> 7)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 8, col: 3 },
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('row');
+    expect(result.error).toContain('out of range');
+  });
+
+  it('should reject col out of range (< 0)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: -1 },
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('col');
+    expect(result.error).toContain('out of range');
+  });
+
+  it('should reject col out of range (> 7)', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 8 },
+    });
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('col');
+    expect(result.error).toContain('out of range');
+  });
+
+  it('should accept empty pose (all null)', () => {
+    const pose = createEmptyPose0();
+
+    const result = validateNaturalHandPose(pose);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject non-object pose', () => {
+    const result = validateNaturalHandPose(null as unknown as NaturalHandPose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('must be an object');
+  });
+
+  it('should reject invalid version', () => {
+    const pose = {
+      ...createDefaultPose0(),
+      version: 2 as const,
+    };
+
+    const result = validateNaturalHandPose(pose as unknown as NaturalHandPose);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('version');
+  });
+});
+
+// ============================================================================
+// Tests: Import → Normalize (Stable Representation)
+// ============================================================================
+
+describe('Import → Normalize', () => {
+  it('should produce stable representation after import and normalize', () => {
+    // Simulate an imported pose with minRow > 0
+    const importedPose: NaturalHandPose = {
+      version: 1,
+      name: 'Imported Pose',
+      positionIndex: 0,
+      fingerToPad: {
+        L_THUMB: null,
+        L_INDEX: { row: 4, col: 2 },
+        L_MIDDLE: { row: 5, col: 3 },
+        L_RING: null,
+        L_PINKY: null,
+        R_THUMB: null,
+        R_INDEX: { row: 6, col: 5 },
+        R_MIDDLE: null,
+        R_RING: null,
+        R_PINKY: null,
+      },
+      maxUpShiftRows: 4,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    // First normalize
+    const normalized1 = normalizePose0(importedPose);
+
+    // Second normalize should be identical (idempotent)
+    const normalized2 = normalizePose0(normalized1);
+
+    // Rows should be the same (both normalized)
+    expect(normalized1.fingerToPad.L_INDEX?.row).toBe(normalized2.fingerToPad.L_INDEX?.row);
+    expect(normalized1.fingerToPad.L_MIDDLE?.row).toBe(normalized2.fingerToPad.L_MIDDLE?.row);
+    expect(normalized1.fingerToPad.R_INDEX?.row).toBe(normalized2.fingerToPad.R_INDEX?.row);
+
+    // Min row should be 0
+    const rows = [
+      normalized1.fingerToPad.L_INDEX?.row,
+      normalized1.fingerToPad.L_MIDDLE?.row,
+      normalized1.fingerToPad.R_INDEX?.row,
+    ].filter((r): r is number => r !== null && r !== undefined);
+
+    expect(Math.min(...rows)).toBe(0);
+  });
+
+  it('should validate imported pose before normalizing', () => {
+    // Invalid pose with duplicate pads should fail validation
+    const invalidImport: NaturalHandPose = {
+      version: 1,
+      name: 'Invalid Import',
+      positionIndex: 0,
+      fingerToPad: {
+        L_THUMB: null,
+        L_INDEX: { row: 2, col: 3 },
+        L_MIDDLE: { row: 2, col: 3 }, // Duplicate!
+        L_RING: null,
+        L_PINKY: null,
+        R_THUMB: null,
+        R_INDEX: null,
+        R_MIDDLE: null,
+        R_RING: null,
+        R_PINKY: null,
+      },
+      maxUpShiftRows: 4,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    const validation = validateNaturalHandPose(invalidImport);
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toContain('Duplicate');
+  });
+
+  it('should preserve relative finger positions after normalization', () => {
+    // Import pose with rows at 4, 5, 6
+    const importedPose: NaturalHandPose = {
+      version: 1,
+      name: 'Test Pose',
+      positionIndex: 0,
+      fingerToPad: {
+        L_THUMB: null,
+        L_INDEX: { row: 4, col: 1 },
+        L_MIDDLE: { row: 5, col: 2 },
+        L_RING: { row: 6, col: 3 },
+        L_PINKY: null,
+        R_THUMB: null,
+        R_INDEX: null,
+        R_MIDDLE: null,
+        R_RING: null,
+        R_PINKY: null,
+      },
+      maxUpShiftRows: 4,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    const normalized = normalizePose0(importedPose);
+
+    // After normalization, rows should be 0, 1, 2 (relative positions preserved)
+    expect(normalized.fingerToPad.L_INDEX).toEqual({ row: 0, col: 1 });
+    expect(normalized.fingerToPad.L_MIDDLE).toEqual({ row: 1, col: 2 });
+    expect(normalized.fingerToPad.L_RING).toEqual({ row: 2, col: 3 });
+  });
+});
+
+// ============================================================================
+// Tests: Conversion Helpers
+// ============================================================================
+
+describe('fingerIdToEngineKey', () => {
+  it('should convert FingerId to engine key format', () => {
+    expect(fingerIdToEngineKey('L_THUMB')).toBe('L1');
+    expect(fingerIdToEngineKey('L_INDEX')).toBe('L2');
+    expect(fingerIdToEngineKey('L_MIDDLE')).toBe('L3');
+    expect(fingerIdToEngineKey('L_RING')).toBe('L4');
+    expect(fingerIdToEngineKey('L_PINKY')).toBe('L5');
+    expect(fingerIdToEngineKey('R_THUMB')).toBe('R1');
+    expect(fingerIdToEngineKey('R_INDEX')).toBe('R2');
+    expect(fingerIdToEngineKey('R_MIDDLE')).toBe('R3');
+    expect(fingerIdToEngineKey('R_RING')).toBe('R4');
+    expect(fingerIdToEngineKey('R_PINKY')).toBe('R5');
+  });
+});
+
+describe('engineKeyToFingerId', () => {
+  it('should convert engine key to FingerId', () => {
+    expect(engineKeyToFingerId('L1')).toBe('L_THUMB');
+    expect(engineKeyToFingerId('L2')).toBe('L_INDEX');
+    expect(engineKeyToFingerId('R5')).toBe('R_PINKY');
+  });
+
+  it('should return null for invalid keys', () => {
+    expect(engineKeyToFingerId('X1')).toBeNull();
+    expect(engineKeyToFingerId('L0')).toBeNull();
+    expect(engineKeyToFingerId('invalid')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Tests: Utility Functions
+// ============================================================================
+
+describe('poseHasAssignments', () => {
+  it('should return false for empty pose', () => {
+    const pose = createEmptyPose0();
+    expect(poseHasAssignments(pose)).toBe(false);
+  });
+
+  it('should return true for pose with at least one assignment', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 3 },
+    });
+    expect(poseHasAssignments(pose)).toBe(true);
+  });
+});
+
+describe('getAssignedFingerCount', () => {
+  it('should return 0 for empty pose', () => {
+    const pose = createEmptyPose0();
+    expect(getAssignedFingerCount(pose)).toBe(0);
+  });
+
+  it('should count assigned fingers correctly', () => {
+    const pose = createPoseWithPads({
+      L_INDEX: { row: 2, col: 3 },
+      L_MIDDLE: { row: 3, col: 4 },
+      R_INDEX: { row: 2, col: 5 },
+    });
+    expect(getAssignedFingerCount(pose)).toBe(3);
+  });
+});

--- a/src/types/naturalHandPose.ts
+++ b/src/types/naturalHandPose.ts
@@ -1,0 +1,501 @@
+/**
+ * Natural Hand Pose Types
+ * 
+ * Defines the data model for user-defined "Natural Hand Pose" configurations.
+ * Pose 0 is the default pose that defines where each finger naturally rests on the grid.
+ * 
+ * TERMINOLOGY (see TERMINOLOGY.md):
+ * - FingerId: Unique identifier for each of the 10 fingers (L_THUMB..R_PINKY)
+ * - PadCoord: Grid position {row: 0-7, col: 0-7}
+ * - NaturalHandPose: Complete pose configuration mapping fingers to pads
+ */
+
+import { FingerType } from '../engine/models';
+import { cellKey } from './layout';
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/**
+ * FingerId: Unique identifier for each finger (10 total).
+ * Format: {Hand}_{Finger} where Hand is L/R and Finger is THUMB/INDEX/MIDDLE/RING/PINKY
+ */
+export type FingerId =
+  | 'L_THUMB'
+  | 'L_INDEX'
+  | 'L_MIDDLE'
+  | 'L_RING'
+  | 'L_PINKY'
+  | 'R_THUMB'
+  | 'R_INDEX'
+  | 'R_MIDDLE'
+  | 'R_RING'
+  | 'R_PINKY';
+
+/**
+ * All FingerId values in a fixed order for iteration.
+ * Order: Left hand (thumb→pinky), then Right hand (thumb→pinky)
+ */
+export const ALL_FINGER_IDS: readonly FingerId[] = [
+  'L_THUMB',
+  'L_INDEX',
+  'L_MIDDLE',
+  'L_RING',
+  'L_PINKY',
+  'R_THUMB',
+  'R_INDEX',
+  'R_MIDDLE',
+  'R_RING',
+  'R_PINKY',
+] as const;
+
+/**
+ * Finger priority order for seeding (per hand): index → middle → ring → thumb → pinky
+ * This order prioritizes the most dexterous fingers first.
+ */
+export const FINGER_PRIORITY_ORDER: readonly FingerId[] = [
+  'L_INDEX',
+  'L_MIDDLE',
+  'L_RING',
+  'L_THUMB',
+  'L_PINKY',
+  'R_INDEX',
+  'R_MIDDLE',
+  'R_RING',
+  'R_THUMB',
+  'R_PINKY',
+] as const;
+
+/**
+ * PadCoord: Grid position on the 8x8 Push grid.
+ * Row 0 is bottom, Row 7 is top. Col 0 is left, Col 7 is right.
+ */
+export interface PadCoord {
+  row: number;
+  col: number;
+}
+
+/**
+ * NaturalHandPose: Complete pose configuration.
+ * Defines where each finger should naturally rest on the grid.
+ */
+export interface NaturalHandPose {
+  /** Schema version for future migrations */
+  version: 1;
+  /** Display name for the pose */
+  name: string;
+  /** Position index (0 = default Natural Hand Pose) */
+  positionIndex: number;
+  /** Mapping of each finger to its pad position (null = unassigned) */
+  fingerToPad: Record<FingerId, PadCoord | null>;
+  /** Maximum vertical shift rows (always 4 for now) */
+  maxUpShiftRows: 4;
+  /** Last updated timestamp (ISO string) */
+  updatedAt: string;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validation result for NaturalHandPose.
+ */
+export interface PoseValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validates a NaturalHandPose object.
+ * 
+ * Rules:
+ * - positionIndex must be 0 for Pose 0
+ * - All assigned pads must have row/col in [0, 7]
+ * - No two fingers can share the same pad (duplicate check)
+ * 
+ * @param pose - The pose to validate
+ * @returns Validation result with error message if invalid
+ */
+export function validateNaturalHandPose(pose: NaturalHandPose): PoseValidationResult {
+  if (!pose || typeof pose !== 'object') {
+    return { valid: false, error: 'Pose must be an object' };
+  }
+
+  if (pose.version !== 1) {
+    return { valid: false, error: `Unsupported pose version: ${pose.version}` };
+  }
+
+  if (typeof pose.positionIndex !== 'number') {
+    return { valid: false, error: 'positionIndex must be a number' };
+  }
+
+  if (!pose.fingerToPad || typeof pose.fingerToPad !== 'object') {
+    return { valid: false, error: 'fingerToPad must be an object' };
+  }
+
+  // Track occupied pads to detect duplicates
+  const occupiedPads = new Map<string, FingerId>();
+
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    
+    if (pad === null || pad === undefined) {
+      continue; // Unassigned is valid
+    }
+
+    if (typeof pad !== 'object') {
+      return { valid: false, error: `${fingerId}: pad must be an object or null` };
+    }
+
+    const { row, col } = pad;
+
+    if (typeof row !== 'number' || typeof col !== 'number') {
+      return { valid: false, error: `${fingerId}: row and col must be numbers` };
+    }
+
+    if (row < 0 || row > 7) {
+      return { valid: false, error: `${fingerId}: row ${row} is out of range [0, 7]` };
+    }
+
+    if (col < 0 || col > 7) {
+      return { valid: false, error: `${fingerId}: col ${col} is out of range [0, 7]` };
+    }
+
+    // Check for duplicate pad assignment
+    const padKey = cellKey(row, col);
+    const existingFinger = occupiedPads.get(padKey);
+    if (existingFinger) {
+      return {
+        valid: false,
+        error: `Duplicate pad at (${row}, ${col}): both ${existingFinger} and ${fingerId} assigned`,
+      };
+    }
+    occupiedPads.set(padKey, fingerId);
+  }
+
+  return { valid: true };
+}
+
+// ============================================================================
+// Default Pose Factory (Built-in)
+// ============================================================================
+
+/**
+ * Built-in default Pose 0 cell positions.
+ * Thumbs at top row; index/middle/ring/pinky in lower rows.
+ * Offset logic ([-4, +4]) is applied when using the pose.
+ */
+const BUILT_IN_POSE0_CELLS: Record<FingerId, PadCoord> = {
+  L_THUMB: { row: 0, col: 3 },
+  L_INDEX: { row: 3, col: 3 },
+  L_MIDDLE: { row: 4, col: 2 },
+  L_RING: { row: 4, col: 1 },
+  L_PINKY: { row: 4, col: 0 },
+  R_THUMB: { row: 0, col: 4 },
+  R_INDEX: { row: 3, col: 4 },
+  R_MIDDLE: { row: 4, col: 5 },
+  R_RING: { row: 4, col: 6 },
+  R_PINKY: { row: 4, col: 7 },
+};
+
+/**
+ * Creates an empty Pose 0 (all fingers unassigned).
+ * Used for tests and when explicitly clearing the pose.
+ */
+export function createEmptyPose0(): NaturalHandPose {
+  const fingerToPad: Record<FingerId, PadCoord | null> = {
+    L_THUMB: null,
+    L_INDEX: null,
+    L_MIDDLE: null,
+    L_RING: null,
+    L_PINKY: null,
+    R_THUMB: null,
+    R_INDEX: null,
+    R_MIDDLE: null,
+    R_RING: null,
+    R_PINKY: null,
+  };
+  return {
+    version: 1,
+    name: 'Empty Pose',
+    positionIndex: 0,
+    fingerToPad,
+    maxUpShiftRows: 4,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Creates the built-in default Pose 0.
+ * All 10 fingers have cell positions; users can edit if desired.
+ */
+export function createDefaultPose0(): NaturalHandPose {
+  const fingerToPad: Record<FingerId, PadCoord | null> = {
+    ...BUILT_IN_POSE0_CELLS,
+  };
+
+  return {
+    version: 1,
+    name: 'Natural Hand Pose',
+    positionIndex: 0,
+    fingerToPad,
+    maxUpShiftRows: 4,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ============================================================================
+// Normalization
+// ============================================================================
+
+/**
+ * Normalizes a pose so that the minimum row becomes 0.
+ * This makes the pose translation-invariant vertically.
+ * 
+ * @param pose - The pose to normalize
+ * @returns A new normalized pose (original is not modified)
+ */
+export function normalizePose0(pose: NaturalHandPose): NaturalHandPose {
+  // Find minimum row among assigned pads
+  let minRow = Infinity;
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    if (pad !== null && pad !== undefined) {
+      minRow = Math.min(minRow, pad.row);
+    }
+  }
+
+  // If no pads assigned, return as-is
+  if (minRow === Infinity) {
+    return { ...pose, updatedAt: new Date().toISOString() };
+  }
+
+  // Shift all rows by -minRow so minimum becomes 0
+  const normalizedFingerToPad: Record<FingerId, PadCoord | null> = {} as Record<FingerId, PadCoord | null>;
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    if (pad === null || pad === undefined) {
+      normalizedFingerToPad[fingerId] = null;
+    } else {
+      normalizedFingerToPad[fingerId] = {
+        row: pad.row - minRow,
+        col: pad.col,
+      };
+    }
+  }
+
+  return {
+    ...pose,
+    fingerToPad: normalizedFingerToPad,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ============================================================================
+// Offset Application
+// ============================================================================
+
+/**
+ * Result of applying offset to a pose.
+ */
+export interface PoseWithOffsetEntry {
+  fingerId: FingerId;
+  row: number;
+  col: number;
+}
+
+/**
+ * Gets the pads from Pose 0 with a vertical offset applied.
+ * 
+ * @param pose - The natural hand pose
+ * @param offsetRow - Signed offset in [-4, +4]. Positive = shift up (increase row), negative = shift down.
+ * @param clamp - If true, clamp rows to [0, 7]; if false, return raw values (may be off-grid)
+ * @returns Array of finger-to-pad entries with offset applied
+ */
+export function getPose0PadsWithOffset(
+  pose: NaturalHandPose,
+  offsetRow: number,
+  clamp: boolean = false
+): PoseWithOffsetEntry[] {
+  const result: PoseWithOffsetEntry[] = [];
+
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    if (pad === null || pad === undefined) {
+      continue;
+    }
+
+    let row = pad.row + offsetRow;
+    const col = pad.col;
+
+    if (clamp) {
+      row = Math.max(0, Math.min(7, row));
+    }
+
+    result.push({ fingerId, row, col });
+  }
+
+  return result;
+}
+
+/**
+ * Checks if a given offset keeps all assigned fingers on-grid.
+ * 
+ * @param pose - The natural hand pose
+ * @param offsetRow - The offset to check
+ * @returns True if all fingers stay within [0, 7] rows
+ */
+export function isOffsetSafe(pose: NaturalHandPose, offsetRow: number): boolean {
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    if (pad === null || pad === undefined) {
+      continue;
+    }
+
+    const row = pad.row + offsetRow;
+    if (row < 0 || row > 7) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Gets the maximum safe offset that keeps all fingers on-grid.
+ * Searches from the preferred direction (positive first for "up").
+ * 
+ * @param pose - The natural hand pose
+ * @param preferPositive - If true, prefer positive offsets (shift up); otherwise prefer negative
+ * @returns The largest safe offset in [-4, +4], or 0 if no fingers assigned
+ */
+export function getMaxSafeOffset(pose: NaturalHandPose, preferPositive: boolean = true): number {
+  // Find min and max rows among assigned pads
+  let minRow = Infinity;
+  let maxRow = -Infinity;
+
+  for (const fingerId of ALL_FINGER_IDS) {
+    const pad = pose.fingerToPad[fingerId];
+    if (pad !== null && pad !== undefined) {
+      minRow = Math.min(minRow, pad.row);
+      maxRow = Math.max(maxRow, pad.row);
+    }
+  }
+
+  // No fingers assigned
+  if (minRow === Infinity) {
+    return 0;
+  }
+
+  // Calculate bounds for safe offset
+  // After offset: row = storedRow + offset
+  // Need: 0 <= storedRow + offset <= 7
+  // So: -storedRow <= offset <= 7 - storedRow
+  // For all fingers: -minRow <= offset <= 7 - maxRow
+  const minSafeOffset = -minRow;
+  const maxSafeOffset = 7 - maxRow;
+
+  // Clamp to [-4, +4]
+  const clampedMin = Math.max(-4, minSafeOffset);
+  const clampedMax = Math.min(4, maxSafeOffset);
+
+  if (preferPositive) {
+    // Return the maximum positive offset that's safe
+    return Math.min(4, clampedMax);
+  } else {
+    // Return the maximum negative offset that's safe
+    // Use || 0 to avoid returning -0
+    return Math.max(-4, clampedMin) || 0;
+  }
+}
+
+// ============================================================================
+// Conversion Helpers
+// ============================================================================
+
+/**
+ * Converts a FingerId to hand ('left' | 'right') and FingerType.
+ * Used for engine/UI integration.
+ */
+export function fingerIdToHandAndFingerType(fingerId: FingerId): {
+  hand: 'left' | 'right';
+  finger: FingerType;
+} {
+  const isLeft = fingerId.startsWith('L_');
+  const fingerPart = fingerId.split('_')[1].toLowerCase() as FingerType;
+
+  return {
+    hand: isLeft ? 'left' : 'right',
+    finger: fingerPart,
+  };
+}
+
+/**
+ * Converts a FingerId to the engine's "L1".."R5" key format.
+ * L1 = Left thumb, L2 = Left index, ..., R5 = Right pinky
+ */
+export function fingerIdToEngineKey(fingerId: FingerId): string {
+  const fingerMap: Record<string, number> = {
+    THUMB: 1,
+    INDEX: 2,
+    MIDDLE: 3,
+    RING: 4,
+    PINKY: 5,
+  };
+
+  const hand = fingerId.startsWith('L_') ? 'L' : 'R';
+  const fingerPart = fingerId.split('_')[1];
+  const num = fingerMap[fingerPart];
+
+  return `${hand}${num}`;
+}
+
+/**
+ * Converts engine key ("L1".."R5") to FingerId.
+ */
+export function engineKeyToFingerId(key: string): FingerId | null {
+  const match = key.match(/^([LR])(\d)$/);
+  if (!match) return null;
+
+  const [, hand, numStr] = match;
+  const num = parseInt(numStr, 10);
+
+  const fingerNames: Record<number, string> = {
+    1: 'THUMB',
+    2: 'INDEX',
+    3: 'MIDDLE',
+    4: 'RING',
+    5: 'PINKY',
+  };
+
+  const fingerName = fingerNames[num];
+  if (!fingerName) return null;
+
+  return `${hand}_${fingerName}` as FingerId;
+}
+
+/**
+ * Checks if a pose has any finger assignments.
+ */
+export function poseHasAssignments(pose: NaturalHandPose): boolean {
+  for (const fingerId of ALL_FINGER_IDS) {
+    if (pose.fingerToPad[fingerId] !== null && pose.fingerToPad[fingerId] !== undefined) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Gets the count of assigned fingers in a pose.
+ */
+export function getAssignedFingerCount(pose: NaturalHandPose): number {
+  let count = 0;
+  for (const fingerId of ALL_FINGER_IDS) {
+    if (pose.fingerToPad[fingerId] !== null && pose.fingerToPad[fingerId] !== undefined) {
+      count++;
+    }
+  }
+  return count;
+}

--- a/src/types/projectState.ts
+++ b/src/types/projectState.ts
@@ -3,6 +3,7 @@ import { Voice, GridMapping } from './layout';
 import { InstrumentConfig } from '../types/performance';
 import { FingerType } from '../engine/models';
 import { EngineResult } from '../engine/core';
+import { NaturalHandPose, createDefaultPose0 } from './naturalHandPose';
 
 export interface LayoutSnapshot {
   id: string;
@@ -64,6 +65,13 @@ export interface ProjectState {
    * Centralizes this state so Workbench, Timeline, and EventAnalysis remain in sync.
    */
   activeMappingId: string | null;
+
+  /**
+   * Natural Hand Pose configurations.
+   * Index 0 is always the default "Pose 0" - the user's natural resting hand position.
+   * Used for deterministic voice-to-pad seeding and as solver neutral position override.
+   */
+  naturalHandPoses?: NaturalHandPose[];
 }
 
 // ============================================================================
@@ -209,4 +217,5 @@ export const createInitialProjectState = (): ProjectState => ({
   solverResults: {},
   activeSolverId: undefined,
   activeMappingId: null,
+  naturalHandPoses: [createDefaultPose0()],
 });

--- a/src/utils/projectPersistence.ts
+++ b/src/utils/projectPersistence.ts
@@ -2,6 +2,11 @@
  * Project persistence utilities for saving and loading project state.
  */
 import { ProjectState, DEFAULT_ENGINE_CONFIGURATION, HAND_SIZE_PRESETS, HandSizePreset } from '../types/projectState';
+import {
+  NaturalHandPose,
+  createDefaultPose0,
+  validateNaturalHandPose,
+} from '../types/naturalHandPose';
 
 /** Structured result for strict project file validation. Invalid core shape fails fast. */
 export type ValidationResult =
@@ -70,6 +75,37 @@ export function validateProjectStrict(parsed: unknown): ValidationResult {
     return { ok: false, error: { code: 'INVALID_MANUAL_ASSIGNMENTS', message: 'manualAssignments must be a nested map of layoutId -> eventKey -> { hand, finger }.', path: 'manualAssignments' } };
   }
 
+  // Validate naturalHandPoses (strict: fail on malformed, default if missing)
+  let naturalHandPoses: NaturalHandPose[];
+  if (p.naturalHandPoses === undefined || p.naturalHandPoses === null) {
+    // Missing is OK for strict (additive field) - create default
+    naturalHandPoses = [createDefaultPose0()];
+  } else if (!Array.isArray(p.naturalHandPoses)) {
+    return { ok: false, error: { code: 'INVALID_NATURAL_HAND_POSES', message: 'naturalHandPoses must be an array.', path: 'naturalHandPoses' } };
+  } else {
+    // Validate each pose strictly
+    naturalHandPoses = [];
+    for (let i = 0; i < p.naturalHandPoses.length; i++) {
+      const pose = p.naturalHandPoses[i] as NaturalHandPose;
+      const validation = validateNaturalHandPose(pose);
+      if (!validation.valid) {
+        return {
+          ok: false,
+          error: {
+            code: 'INVALID_POSE',
+            message: `naturalHandPoses[${i}]: ${validation.error}`,
+            path: `naturalHandPoses[${i}]`,
+          },
+        };
+      }
+      naturalHandPoses.push(pose);
+    }
+    // Ensure Pose 0 exists
+    if (naturalHandPoses.length === 0) {
+      naturalHandPoses = [createDefaultPose0()];
+    }
+  }
+
   // Apply defaults/migrations for non-critical fields
   let engineConfig = (p.engineConfiguration && typeof p.engineConfiguration === 'object')
     ? p.engineConfiguration as Record<string, unknown>
@@ -94,6 +130,7 @@ export function validateProjectStrict(parsed: unknown): ValidationResult {
     engineConfiguration: engineConfig as ProjectState['engineConfiguration'],
     solverResults: (p.solverResults && typeof p.solverResults === 'object') ? p.solverResults : {},
     activeSolverId: p.activeSolverId !== undefined ? (p.activeSolverId as string) : undefined,
+    naturalHandPoses,
   };
   return { ok: true, state };
 }
@@ -120,6 +157,24 @@ export function validateProjectState(parsed: unknown): ProjectState {
     ? p.instrumentConfig
     : (Array.isArray(p.instrumentConfigs) && p.instrumentConfigs[0] != null) ? p.instrumentConfigs[0] : null;
 
+  // Lenient handling for naturalHandPoses: default if missing/invalid
+  let naturalHandPoses: NaturalHandPose[] = [createDefaultPose0()];
+  if (Array.isArray(p.naturalHandPoses) && p.naturalHandPoses.length > 0) {
+    // Try to use existing poses, filter out invalid ones
+    const validPoses: NaturalHandPose[] = [];
+    for (const pose of p.naturalHandPoses) {
+      if (pose && typeof pose === 'object') {
+        const validation = validateNaturalHandPose(pose as NaturalHandPose);
+        if (validation.valid) {
+          validPoses.push(pose as NaturalHandPose);
+        }
+      }
+    }
+    if (validPoses.length > 0) {
+      naturalHandPoses = validPoses;
+    }
+  }
+
   return {
     layouts: Array.isArray(p.layouts) ? p.layouts as ProjectState['layouts'] : [],
     sectionMaps: Array.isArray(p.sectionMaps) ? p.sectionMaps : [],
@@ -135,6 +190,7 @@ export function validateProjectState(parsed: unknown): ProjectState {
     engineConfiguration: engineConfig as ProjectState['engineConfiguration'],
     solverResults: (p.solverResults && typeof p.solverResults === 'object') ? p.solverResults : {},
     activeSolverId: p.activeSolverId !== undefined ? p.activeSolverId : undefined,
+    naturalHandPoses,
   };
 }
 

--- a/src/workbench/LayoutDesigner.tsx
+++ b/src/workbench/LayoutDesigner.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -41,7 +41,8 @@ import { ProjectState, LayoutSnapshot } from '../types/projectState';
 import { EngineResult } from '../engine/core';
 import { VoiceLibrary } from './VoiceLibrary';
 import { FingerLegend } from './FingerLegend';
-
+import { NaturalHandPosePanel, getPoseGhostMarkers, handlePoseEditPadClick } from './NaturalHandPosePanel';
+import { FingerId, NaturalHandPose, createDefaultPose0 } from '../types/naturalHandPose';
 
 import { getActivePerformance } from '../utils/performanceSelectors';
 
@@ -129,6 +130,10 @@ interface DroppableCellProps {
   onClick: () => void;
   onDoubleClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
+  /** Ghost marker for Natural Hand Pose visualization */
+  poseGhostMarker?: { shortName: string; color: string; isOffGrid: boolean } | null;
+  /** Whether pose edit mode is active */
+  isPoseEditMode?: boolean;
 }
 
 const DroppableCell: React.FC<DroppableCellProps & { onUpdateSound?: (updates: Partial<Voice>) => void }> = ({
@@ -151,6 +156,8 @@ const DroppableCell: React.FC<DroppableCellProps & { onUpdateSound?: (updates: P
   onDoubleClick,
   onContextMenu,
   onUpdateSound,
+  poseGhostMarker,
+  isPoseEditMode = false,
 }) => {
   // Get Cell (MIDI note number) for label display on this Pad
   const noteNumber = assignedSound && assignedSound.originalMidiNote !== null
@@ -380,6 +387,23 @@ const DroppableCell: React.FC<DroppableCellProps & { onUpdateSound?: (updates: P
               <span className="text-[8px]">🔒</span>
             </div>
           )}
+
+          {/* Pose Ghost Marker (Bottom Left) - Show when pose has this pad assigned */}
+          {poseGhostMarker && (
+            <div
+              className={`absolute -bottom-1.5 -left-1.5 w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-bold shadow-md z-10 border-2 border-white/30 ${
+                poseGhostMarker.isOffGrid ? 'opacity-40' : ''
+              }`}
+              style={{
+                backgroundColor: poseGhostMarker.color,
+                color: 'white',
+                textShadow: '0 1px 2px rgba(0,0,0,0.5)',
+              }}
+              title={`Natural Pose: ${poseGhostMarker.shortName}${poseGhostMarker.isOffGrid ? ' (off-grid)' : ''}`}
+            >
+              {poseGhostMarker.shortName}
+            </div>
+          )}
         </>
       ) : (
         <>
@@ -418,6 +442,23 @@ const DroppableCell: React.FC<DroppableCellProps & { onUpdateSound?: (updates: P
                 <span className="text-[8px] text-[var(--text-secondary)] font-mono opacity-0 hover:opacity-100 transition-opacity">
                   {row},{col}
                 </span>
+              )}
+
+              {/* Pose Ghost Marker for empty cells */}
+              {poseGhostMarker && (
+                <div
+                  className={`absolute inset-2 rounded-lg flex items-center justify-center ${
+                    poseGhostMarker.isOffGrid ? 'opacity-40' : 'opacity-70'
+                  } ${isPoseEditMode ? 'ring-2 ring-dashed ring-white/50' : ''}`}
+                  style={{
+                    backgroundColor: poseGhostMarker.color,
+                  }}
+                  title={`Natural Pose: ${poseGhostMarker.shortName}${poseGhostMarker.isOffGrid ? ' (off-grid)' : ''}`}
+                >
+                  <span className="text-[11px] font-bold text-white drop-shadow-md">
+                    {poseGhostMarker.shortName}
+                  </span>
+                </div>
               )}
             </>
           )}
@@ -532,7 +573,40 @@ export const LayoutDesigner: React.FC<LayoutDesignerProps> = ({
 
     return map;
   }, [engineResult, projectState]);
-  // const [leftPanelTab, setLeftPanelTab] = useState<'library'>('library');
+
+  // Left Panel Tab State
+  const [leftPanelTab, setLeftPanelTab] = useState<'library' | 'pose'>('library');
+
+  // Pose Editor State
+  const [isPoseEditMode, setIsPoseEditMode] = useState(false);
+  const [activeFinger, setActiveFinger] = useState<FingerId | null>(null);
+  const [previewOffset, setPreviewOffset] = useState(0);
+
+  // Get Pose 0 from project state (or create default)
+  const pose0: NaturalHandPose = projectState.naturalHandPoses?.[0] ?? createDefaultPose0();
+
+  // Update Pose 0 in project state
+  const handleUpdatePose0 = useCallback((pose: NaturalHandPose) => {
+    const newPoses = [...(projectState.naturalHandPoses ?? [createDefaultPose0()])];
+    newPoses[0] = pose;
+    onUpdateProjectState({
+      ...projectState,
+      naturalHandPoses: newPoses,
+    });
+  }, [projectState, onUpdateProjectState]);
+
+  // Toggle pose edit mode
+  const handleTogglePoseEditMode = useCallback(() => {
+    setIsPoseEditMode(prev => !prev);
+    if (isPoseEditMode) {
+      setActiveFinger(null); // Clear active finger when exiting edit mode
+    }
+  }, [isPoseEditMode]);
+
+  // Get ghost markers for pose visualization
+  const poseGhostMarkers = useMemo(() => {
+    return getPoseGhostMarkers(pose0, previewOffset);
+  }, [pose0, previewOffset]);
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
@@ -790,8 +864,18 @@ export const LayoutDesigner: React.FC<LayoutDesignerProps> = ({
 
 
 
-  // Handle cell click - selects the sound asset at that coordinate
+  // Handle cell click - selects the sound asset at that coordinate OR assigns finger in pose edit mode
   const handleCellClick = (row: number, col: number) => {
+    // Handle pose edit mode: assign active finger to this pad
+    if (isPoseEditMode && leftPanelTab === 'pose') {
+      const result = handlePoseEditPadClick(row, col, activeFinger, pose0, handleUpdatePose0);
+      if (!result.success && result.message) {
+        console.log('[LayoutDesigner] Pose edit:', result.message);
+      }
+      return; // Don't do normal cell selection in pose edit mode
+    }
+
+    // Normal cell click behavior
     const key = cellKey(row, col);
     const sound = getCellSound(row, col);
     if (sound) {
@@ -977,36 +1061,77 @@ export const LayoutDesigner: React.FC<LayoutDesignerProps> = ({
 
         {/* Main Content Area - Strict 3-Column Layout */}
         <div className="flex-1 flex flex-row overflow-hidden">
-          {/* Left Panel (w-80) - Tabbed: Library & Sections */}
+          {/* Left Panel (w-80) - Tabbed: Library | Pose */}
           <div className="w-80 flex-none border-r border-[var(--border-subtle)] bg-[var(--bg-app)] flex flex-col overflow-hidden">
-            {/* Layout Actions Removed - Moved to Icons */}
+            {/* Top-level Tabs: Library | Pose */}
+            <div className="flex-none border-b border-[var(--border-subtle)]">
+              <div className="flex">
+                <button
+                  onClick={() => {
+                    setLeftPanelTab('library');
+                    if (isPoseEditMode) {
+                      setIsPoseEditMode(false);
+                      setActiveFinger(null);
+                    }
+                  }}
+                  className={`flex-1 px-4 py-2 text-xs font-medium transition-colors ${
+                    leftPanelTab === 'library'
+                      ? 'text-[var(--text-primary)] border-b-2 border-blue-500 bg-[var(--bg-panel)]'
+                      : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]'
+                  }`}
+                >
+                  Library
+                </button>
+                <button
+                  onClick={() => setLeftPanelTab('pose')}
+                  className={`flex-1 px-4 py-2 text-xs font-medium transition-colors ${
+                    leftPanelTab === 'pose'
+                      ? 'text-[var(--text-primary)] border-b-2 border-blue-500 bg-[var(--bg-panel)]'
+                      : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-card)]'
+                  }`}
+                >
+                  Pose
+                </button>
+              </div>
+            </div>
 
-            {/* Tabs (Removed - VoiceLibrary handles this) */}
-
-            {/* Voice Library Component */}
-            <VoiceLibrary
-              parkedSounds={stagingAssets}
-              activeMapping={activeMapping}
-              projectState={projectState}
-              selectedSoundId={selectedSoundId}
-              selectedCellKey={selectedCellKey}
-              ignoredNoteNumbers={ignoredNoteNumbers}
-              onSelectSound={(id) => {
-                setSelectedSoundId(id);
-                setSelectedCellKey(null);
-              }}
-              onSelectCell={(key) => {
-                setSelectedCellKey(key);
-                setSelectedSoundId(null);
-              }}
-              onAddSound={onAddSound}
-              onUpdateSound={onUpdateSound}
-              onUpdateMappingSound={onUpdateMappingSound}
-              onDeleteSound={(id) => onDeleteSound?.(id)}
-              onToggleVoiceVisibility={handleToggleVoiceVisibility}
-              handleDestructiveDelete={handleDestructiveDelete}
-              handleClearStaging={handleClearStaging}
-            />
+            {/* Tab Content */}
+            {leftPanelTab === 'library' ? (
+              <VoiceLibrary
+                parkedSounds={stagingAssets}
+                activeMapping={activeMapping}
+                projectState={projectState}
+                selectedSoundId={selectedSoundId}
+                selectedCellKey={selectedCellKey}
+                ignoredNoteNumbers={ignoredNoteNumbers}
+                onSelectSound={(id) => {
+                  setSelectedSoundId(id);
+                  setSelectedCellKey(null);
+                }}
+                onSelectCell={(key) => {
+                  setSelectedCellKey(key);
+                  setSelectedSoundId(null);
+                }}
+                onAddSound={onAddSound}
+                onUpdateSound={onUpdateSound}
+                onUpdateMappingSound={onUpdateMappingSound}
+                onDeleteSound={(id) => onDeleteSound?.(id)}
+                onToggleVoiceVisibility={handleToggleVoiceVisibility}
+                handleDestructiveDelete={handleDestructiveDelete}
+                handleClearStaging={handleClearStaging}
+              />
+            ) : (
+              <NaturalHandPosePanel
+                pose0={pose0}
+                onUpdatePose0={handleUpdatePose0}
+                activeFinger={activeFinger}
+                onSetActiveFinger={setActiveFinger}
+                previewOffset={previewOffset}
+                onSetPreviewOffset={setPreviewOffset}
+                isEditMode={isPoseEditMode}
+                onToggleEditMode={handleTogglePoseEditMode}
+              />
+            )}
           </div>
 
           {/* Center Panel (flex-1) - GridEditor (top) & Timeline (bottom) */}
@@ -1076,6 +1201,11 @@ export const LayoutDesigner: React.FC<LayoutDesignerProps> = ({
                       // Get finger constraint for this cell
                       const fingerConstraint = activeMapping?.fingerConstraints[cellKeyStr] || null;
 
+                      // Pose ghost markers only visible during pose edit mode (backend data otherwise)
+                      const ghostMarker = (isPoseEditMode && leftPanelTab === 'pose')
+                        ? poseGhostMarkers.get(cellKeyStr)
+                        : undefined;
+
                       return (
                         <DroppableCell
                           key={key}
@@ -1098,6 +1228,8 @@ export const LayoutDesigner: React.FC<LayoutDesignerProps> = ({
                           onClick={() => handleCellClick(row, col)}
                           onDoubleClick={() => handleCellDoubleClick(row, col)}
                           onContextMenu={(e) => handleCellContextMenu(e, row, col)}
+                          poseGhostMarker={ghostMarker ?? null}
+                          isPoseEditMode={isPoseEditMode && leftPanelTab === 'pose'}
                         />
                       );
                     })}

--- a/src/workbench/NaturalHandPosePanel.tsx
+++ b/src/workbench/NaturalHandPosePanel.tsx
@@ -1,0 +1,560 @@
+/**
+ * NaturalHandPosePanel Component
+ * 
+ * UI for editing the Natural Hand Pose (Pose 0) - the user's preferred
+ * resting hand position on the Push 3 grid.
+ * 
+ * Features:
+ * - Active finger tool: click finger, then click pad to assign
+ * - Keyboard shortcuts: 1-5 for left hand, 6-0 for right hand
+ * - Preview offset: signed [-4, +4] to shift pose vertically
+ * - Built-in default pose; edit via finger palette
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  NaturalHandPose,
+  FingerId,
+  ALL_FINGER_IDS,
+  PadCoord,
+  normalizePose0,
+  validateNaturalHandPose,
+  poseHasAssignments,
+  getAssignedFingerCount,
+  getPose0PadsWithOffset,
+  getMaxSafeOffset,
+  isOffsetSafe,
+} from '../types/naturalHandPose';
+import { cellKey } from '../types/layout';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface NaturalHandPosePanelProps {
+  /** Current Pose 0 from project state */
+  pose0: NaturalHandPose;
+  /** Callback to update Pose 0 */
+  onUpdatePose0: (pose: NaturalHandPose) => void;
+  /** Currently active finger tool (null = no tool selected) */
+  activeFinger: FingerId | null;
+  /** Callback to set active finger tool */
+  onSetActiveFinger: (finger: FingerId | null) => void;
+  /** Preview offset for visualization */
+  previewOffset: number;
+  /** Callback to set preview offset */
+  onSetPreviewOffset: (offset: number) => void;
+  /** Whether pose edit mode is active */
+  isEditMode: boolean;
+  /** Callback to toggle edit mode */
+  onToggleEditMode: () => void;
+}
+
+// ============================================================================
+// Finger Display Helpers
+// ============================================================================
+
+/** Short display name for finger (e.g., "L1" for L_THUMB) */
+function getFingerShortName(fingerId: FingerId): string {
+  const fingerNum: Record<string, number> = {
+    THUMB: 1,
+    INDEX: 2,
+    MIDDLE: 3,
+    RING: 4,
+    PINKY: 5,
+  };
+  const hand = fingerId.startsWith('L_') ? 'L' : 'R';
+  const fingerPart = fingerId.split('_')[1];
+  return `${hand}${fingerNum[fingerPart]}`;
+}
+
+/** Full display name for finger (e.g., "Left Thumb") */
+function getFingerDisplayName(fingerId: FingerId): string {
+  const hand = fingerId.startsWith('L_') ? 'Left' : 'Right';
+  const fingerPart = fingerId.split('_')[1];
+  const fingerName = fingerPart.charAt(0) + fingerPart.slice(1).toLowerCase();
+  return `${hand} ${fingerName}`;
+}
+
+/** Get finger color based on hand and finger type */
+function getFingerColor(fingerId: FingerId): string {
+  // Use CSS variables matching the existing finger legend
+  const isLeft = fingerId.startsWith('L_');
+  const fingerNum: Record<string, number> = {
+    THUMB: 1,
+    INDEX: 2,
+    MIDDLE: 3,
+    RING: 4,
+    PINKY: 5,
+  };
+  const num = fingerNum[fingerId.split('_')[1]];
+  return `var(--finger-${isLeft ? 'L' : 'R'}${num})`;
+}
+
+/** Keyboard shortcut for finger (1-5 left, 6-0 right) */
+function getFingerShortcut(fingerId: FingerId): string {
+  const shortcuts: Record<FingerId, string> = {
+    L_THUMB: '1',
+    L_INDEX: '2',
+    L_MIDDLE: '3',
+    L_RING: '4',
+    L_PINKY: '5',
+    R_THUMB: '6',
+    R_INDEX: '7',
+    R_MIDDLE: '8',
+    R_RING: '9',
+    R_PINKY: '0',
+  };
+  return shortcuts[fingerId];
+}
+
+/** Map keyboard key to FingerId */
+function keyToFingerId(key: string): FingerId | null {
+  const keyMap: Record<string, FingerId> = {
+    '1': 'L_THUMB',
+    '2': 'L_INDEX',
+    '3': 'L_MIDDLE',
+    '4': 'L_RING',
+    '5': 'L_PINKY',
+    '6': 'R_THUMB',
+    '7': 'R_INDEX',
+    '8': 'R_MIDDLE',
+    '9': 'R_RING',
+    '0': 'R_PINKY',
+  };
+  return keyMap[key] || null;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export const NaturalHandPosePanel: React.FC<NaturalHandPosePanelProps> = ({
+  pose0,
+  onUpdatePose0,
+  activeFinger,
+  onSetActiveFinger,
+  previewOffset,
+  onSetPreviewOffset,
+  isEditMode,
+  onToggleEditMode,
+}) => {
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  // Calculate max safe offset for current pose
+  const maxSafePositive = getMaxSafeOffset(pose0, true);
+  const maxSafeNegative = getMaxSafeOffset(pose0, false);
+  const isSafeOffset = isOffsetSafe(pose0, previewOffset);
+
+  // Keyboard shortcuts for finger selection
+  useEffect(() => {
+    if (!isEditMode) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't capture if user is typing in an input
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      // Escape clears selection
+      if (e.key === 'Escape') {
+        onSetActiveFinger(null);
+        return;
+      }
+
+      // Number keys select fingers
+      const fingerId = keyToFingerId(e.key);
+      if (fingerId) {
+        onSetActiveFinger(fingerId);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isEditMode, onSetActiveFinger]);
+
+  // Clear status message after a delay
+  useEffect(() => {
+    if (statusMessage) {
+      const timer = setTimeout(() => setStatusMessage(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [statusMessage]);
+
+  // Handle finger button click
+  const handleFingerClick = useCallback((fingerId: FingerId) => {
+    if (activeFinger === fingerId) {
+      onSetActiveFinger(null); // Toggle off
+    } else {
+      onSetActiveFinger(fingerId);
+    }
+  }, [activeFinger, onSetActiveFinger]);
+
+  // Handle saving pose (with normalization)
+  const handleSavePose = useCallback(() => {
+    const normalized = normalizePose0(pose0);
+    const validation = validateNaturalHandPose(normalized);
+    
+    if (!validation.valid) {
+      setStatusMessage(`Error: ${validation.error}`);
+      return;
+    }
+
+    onUpdatePose0(normalized);
+    setStatusMessage('Pose saved successfully');
+  }, [pose0, onUpdatePose0]);
+
+  // Handle clearing a single finger
+  const handleClearFinger = useCallback((fingerId: FingerId) => {
+    const newFingerToPad = { ...pose0.fingerToPad };
+    newFingerToPad[fingerId] = null;
+    onUpdatePose0({
+      ...pose0,
+      fingerToPad: newFingerToPad,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [pose0, onUpdatePose0]);
+
+  // Handle clearing all fingers
+  const handleClearAll = useCallback(() => {
+    const newFingerToPad: Record<FingerId, PadCoord | null> = {} as Record<FingerId, PadCoord | null>;
+    for (const fingerId of ALL_FINGER_IDS) {
+      newFingerToPad[fingerId] = null;
+    }
+    onUpdatePose0({
+      ...pose0,
+      fingerToPad: newFingerToPad,
+      updatedAt: new Date().toISOString(),
+    });
+    setStatusMessage('All finger assignments cleared');
+  }, [pose0, onUpdatePose0]);
+
+  // Get pads with current preview offset for display
+  const padsWithOffset = getPose0PadsWithOffset(pose0, previewOffset, false);
+  const offGridFingers = padsWithOffset.filter(p => p.row < 0 || p.row > 7);
+
+  const assignedCount = getAssignedFingerCount(pose0);
+  const hasAssignments = poseHasAssignments(pose0);
+
+  return (
+    <div className="flex flex-col h-full bg-[var(--bg-panel)]">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-[var(--border-subtle)]">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+            Natural Hand Pose
+          </h3>
+          <button
+            onClick={onToggleEditMode}
+            className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+              isEditMode
+                ? 'bg-blue-600 text-white'
+                : 'bg-[var(--bg-card)] text-[var(--text-secondary)] hover:bg-[var(--bg-card-hover)]'
+            }`}
+          >
+            {isEditMode ? 'Done Editing' : 'Edit Pose'}
+          </button>
+        </div>
+        <p className="text-xs text-[var(--text-tertiary)] mt-1">
+          {assignedCount}/10 fingers assigned
+        </p>
+      </div>
+
+      {/* Status Message */}
+      {statusMessage && (
+        <div className={`px-4 py-2 text-xs ${
+          statusMessage.startsWith('Error') 
+            ? 'bg-red-900/30 text-red-300' 
+            : 'bg-green-900/30 text-green-300'
+        }`}>
+          {statusMessage}
+        </div>
+      )}
+
+      {/* Edit Mode Content */}
+      {isEditMode && (
+        <div className="flex-1 overflow-y-auto">
+          {/* Instructions */}
+          <div className="px-4 py-3 bg-[var(--bg-card)] border-b border-[var(--border-subtle)]">
+            <p className="text-xs text-[var(--text-secondary)]">
+              <strong>Click a finger</strong> below, then <strong>click a pad</strong> on the grid to assign.
+            </p>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">
+              Shortcuts: 1-5 (left hand), 6-0 (right hand), Esc (clear)
+            </p>
+          </div>
+
+          {/* Finger Palette - Left Hand */}
+          <div className="px-4 py-3 border-b border-[var(--border-subtle)]">
+            <h4 className="text-xs font-medium text-[var(--text-secondary)] mb-2">Left Hand</h4>
+            <div className="flex flex-wrap gap-2">
+              {ALL_FINGER_IDS.filter(f => f.startsWith('L_')).map(fingerId => {
+                const isActive = activeFinger === fingerId;
+                const pad = pose0.fingerToPad[fingerId];
+                const hasAssignment = pad !== null && pad !== undefined;
+
+                return (
+                  <button
+                    key={fingerId}
+                    onClick={() => handleFingerClick(fingerId)}
+                    className={`relative px-2 py-1.5 text-xs font-medium rounded transition-all ${
+                      isActive
+                        ? 'ring-2 ring-white shadow-lg scale-105'
+                        : 'hover:scale-102'
+                    }`}
+                    style={{
+                      backgroundColor: getFingerColor(fingerId),
+                      color: 'white',
+                    }}
+                    title={`${getFingerDisplayName(fingerId)} (${getFingerShortcut(fingerId)})`}
+                  >
+                    <span className="flex items-center gap-1">
+                      <span>{getFingerShortName(fingerId)}</span>
+                      {hasAssignment && (
+                        <span className="text-[10px] opacity-75">
+                          ({pad.row},{pad.col})
+                        </span>
+                      )}
+                    </span>
+                    {hasAssignment && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleClearFinger(fingerId);
+                        }}
+                        className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full text-white text-[10px] flex items-center justify-center hover:bg-red-400"
+                        title="Clear assignment"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Finger Palette - Right Hand */}
+          <div className="px-4 py-3 border-b border-[var(--border-subtle)]">
+            <h4 className="text-xs font-medium text-[var(--text-secondary)] mb-2">Right Hand</h4>
+            <div className="flex flex-wrap gap-2">
+              {ALL_FINGER_IDS.filter(f => f.startsWith('R_')).map(fingerId => {
+                const isActive = activeFinger === fingerId;
+                const pad = pose0.fingerToPad[fingerId];
+                const hasAssignment = pad !== null && pad !== undefined;
+
+                return (
+                  <button
+                    key={fingerId}
+                    onClick={() => handleFingerClick(fingerId)}
+                    className={`relative px-2 py-1.5 text-xs font-medium rounded transition-all ${
+                      isActive
+                        ? 'ring-2 ring-white shadow-lg scale-105'
+                        : 'hover:scale-102'
+                    }`}
+                    style={{
+                      backgroundColor: getFingerColor(fingerId),
+                      color: 'white',
+                    }}
+                    title={`${getFingerDisplayName(fingerId)} (${getFingerShortcut(fingerId)})`}
+                  >
+                    <span className="flex items-center gap-1">
+                      <span>{getFingerShortName(fingerId)}</span>
+                      {hasAssignment && (
+                        <span className="text-[10px] opacity-75">
+                          ({pad.row},{pad.col})
+                        </span>
+                      )}
+                    </span>
+                    {hasAssignment && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleClearFinger(fingerId);
+                        }}
+                        className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full text-white text-[10px] flex items-center justify-center hover:bg-red-400"
+                        title="Clear assignment"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Active Tool Indicator */}
+          {activeFinger && (
+            <div className="px-4 py-2 bg-blue-900/30 border-b border-[var(--border-subtle)]">
+              <p className="text-xs text-blue-300">
+                Active: <strong>{getFingerDisplayName(activeFinger)}</strong> — click a pad to assign
+              </p>
+            </div>
+          )}
+
+          {/* Preview Offset */}
+          <div className="px-4 py-3 border-b border-[var(--border-subtle)]">
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-xs font-medium text-[var(--text-secondary)]">Preview Offset</h4>
+              <span className="text-xs text-[var(--text-tertiary)]">
+                {previewOffset > 0 ? '+' : ''}{previewOffset} rows
+              </span>
+            </div>
+            <input
+              type="range"
+              min={-4}
+              max={4}
+              value={previewOffset}
+              onChange={(e) => onSetPreviewOffset(parseInt(e.target.value, 10))}
+              className="w-full h-2 bg-[var(--bg-card)] rounded-lg appearance-none cursor-pointer"
+            />
+            <div className="flex justify-between text-[10px] text-[var(--text-tertiary)] mt-1">
+              <span>-4 (down)</span>
+              <span>0</span>
+              <span>+4 (up)</span>
+            </div>
+            {!isSafeOffset && offGridFingers.length > 0 && (
+              <p className="text-xs text-amber-400 mt-2">
+                {offGridFingers.length} finger(s) off-grid at this offset
+              </p>
+            )}
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">
+              Safe range: {maxSafeNegative} to {maxSafePositive > 0 ? '+' : ''}{maxSafePositive}
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="px-4 py-3 space-y-2">
+            <button
+              onClick={handleSavePose}
+              disabled={!hasAssignments}
+              className="w-full px-3 py-2 text-xs font-medium bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Save & Normalize Pose
+            </button>
+            <button
+              onClick={handleClearAll}
+              disabled={!hasAssignments}
+              className="w-full px-3 py-2 text-xs font-medium bg-[var(--bg-card)] text-[var(--text-secondary)] rounded hover:bg-red-900/30 hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Clear All Assignments
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Non-Edit Mode: Summary */}
+      {!isEditMode && (
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-4 py-3">
+            {hasAssignments ? (
+              <>
+                <p className="text-xs text-[var(--text-secondary)] mb-2">
+                  Your natural hand pose is configured. Click "Edit Pose" to modify.
+                </p>
+                <p className="text-xs text-[var(--text-tertiary)] mb-3">
+                  Use <strong>Natural</strong> in the toolbar to assign sounds to these pads first. <strong>Auto-Arrange</strong> and <strong>Run Analysis</strong> use this pose as the preferred home position.
+                </p>
+                <div className="space-y-2">
+                  {ALL_FINGER_IDS.map(fingerId => {
+                    const pad = pose0.fingerToPad[fingerId];
+                    if (!pad) return null;
+                    return (
+                      <div
+                        key={fingerId}
+                        className="flex items-center justify-between px-2 py-1 rounded"
+                        style={{ backgroundColor: `${getFingerColor(fingerId)}20` }}
+                      >
+                        <span className="text-xs text-[var(--text-primary)]">
+                          {getFingerDisplayName(fingerId)}
+                        </span>
+                        <span className="text-xs text-[var(--text-tertiary)]">
+                          ({pad.row}, {pad.col})
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            ) : (
+              <p className="text-xs text-[var(--text-tertiary)] italic">
+                No pose configured yet. Click "Edit Pose" to set your natural hand position.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// Grid Ghost Markers Helper
+// ============================================================================
+
+/**
+ * Get ghost marker data for rendering Pose 0 on the grid.
+ * Returns a map of cellKey -> { fingerId, isOffGrid }
+ */
+export function getPoseGhostMarkers(
+  pose0: NaturalHandPose,
+  previewOffset: number
+): Map<string, { fingerId: FingerId; shortName: string; color: string; isOffGrid: boolean }> {
+  const markers = new Map<string, { fingerId: FingerId; shortName: string; color: string; isOffGrid: boolean }>();
+  
+  const padsWithOffset = getPose0PadsWithOffset(pose0, previewOffset, false);
+  
+  for (const { fingerId, row, col } of padsWithOffset) {
+    const isOffGrid = row < 0 || row > 7;
+    const clampedRow = Math.max(0, Math.min(7, row));
+    const key = cellKey(clampedRow, col);
+    
+    markers.set(key, {
+      fingerId,
+      shortName: getFingerShortName(fingerId),
+      color: getFingerColor(fingerId),
+      isOffGrid,
+    });
+  }
+  
+  return markers;
+}
+
+/**
+ * Handle pad click during pose edit mode.
+ * Assigns the active finger to the clicked pad.
+ */
+export function handlePoseEditPadClick(
+  row: number,
+  col: number,
+  activeFinger: FingerId | null,
+  pose0: NaturalHandPose,
+  onUpdatePose0: (pose: NaturalHandPose) => void
+): { success: boolean; message?: string } {
+  if (!activeFinger) {
+    return { success: false, message: 'Select a finger first' };
+  }
+
+  // Check if this pad is already assigned to another finger
+  const existingFinger = Object.entries(pose0.fingerToPad).find(
+    ([, pad]) => pad !== null && pad.row === row && pad.col === col
+  )?.[0] as FingerId | undefined;
+
+  const newFingerToPad = { ...pose0.fingerToPad };
+
+  // If pad is already assigned to another finger, clear that assignment
+  if (existingFinger && existingFinger !== activeFinger) {
+    newFingerToPad[existingFinger] = null;
+  }
+
+  // Assign active finger to this pad
+  newFingerToPad[activeFinger] = { row, col };
+
+  onUpdatePose0({
+    ...pose0,
+    fingerToPad: newFingerToPad,
+    updatedAt: new Date().toISOString(),
+  });
+
+  return { success: true };
+}

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -11,6 +11,13 @@ import { mapToQuadrants } from '../utils/autoLayout';
 import { BiomechanicalSolver, SolverType } from '../engine/core';
 import { FingerType } from '../engine/models';
 import { getActivePerformance } from '../utils/performanceSelectors';
+import {
+  FINGER_PRIORITY_ORDER,
+  getPose0PadsWithOffset,
+  getMaxSafeOffset,
+  poseHasAssignments,
+  createDefaultPose0,
+} from '../types/naturalHandPose';
 import { AnalysisPanel } from './AnalysisPanel';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { songService } from '../services/SongService';
@@ -826,6 +833,140 @@ export const Workbench: React.FC = () => {
   };
 
   // ============================================================================
+  // EXPLICIT LAYOUT CONTROL: Assign Using Natural Pose (Deterministic)
+  // ============================================================================
+  // Maps unassigned Voices to Pads using Pose 0 anchor pads as priority,
+  // sorted by voice importance (note-on count). Deterministic, not random.
+  // ============================================================================
+  const handleAutoAssignNaturalPose = () => {
+    if (!activeMapping || !projectState.instrumentConfig) {
+      alert('No active mapping or instrument config available. Please create a mapping first.');
+      return;
+    }
+
+    // Get Pose 0
+    const pose0 = projectState.naturalHandPoses?.[0] ?? createDefaultPose0();
+    if (!poseHasAssignments(pose0)) {
+      alert('No Natural Hand Pose configured. Please configure Pose 0 first, or use Random assignment.');
+      return;
+    }
+
+    // Find all unassigned Voices (in staging, not yet assigned to a Pad)
+    const assignedIds = new Set(Object.values(activeMapping.cells).map(v => v.id));
+    const unassignedVoices = projectState.parkedSounds.filter(s => !assignedIds.has(s.id));
+
+    if (unassignedVoices.length === 0) {
+      alert('No unassigned Voices found. All Voices are already assigned to Pads.');
+      return;
+    }
+
+    // Sort voices by importance (note-on count, descending - most important first)
+    // Calculate importance from the active performance
+    const performance = getActivePerformance(projectState);
+    const voiceImportance = new Map<string, number>();
+    if (performance) {
+      for (const event of performance.events) {
+        const voice = unassignedVoices.find(v => v.originalMidiNote === event.noteNumber);
+        if (voice) {
+          voiceImportance.set(voice.id, (voiceImportance.get(voice.id) || 0) + 1);
+        }
+      }
+    }
+    
+    // Sort by importance (descending)
+    const sortedVoices = [...unassignedVoices].sort((a, b) => {
+      const importanceA = voiceImportance.get(a.id) || 0;
+      const importanceB = voiceImportance.get(b.id) || 0;
+      return importanceB - importanceA;
+    });
+
+    // Get Pose 0 anchor pads with max safe offset
+    const safeOffset = getMaxSafeOffset(pose0, true);
+    const anchorPads = getPose0PadsWithOffset(pose0, safeOffset, true);
+    
+    // Build ordered pad list: anchor pads first (in finger priority order), then other empty pads
+    const anchorPadKeys = new Set<string>();
+    const orderedPads: Array<{ row: number; col: number; key: string }> = [];
+    
+    // Add anchor pads in finger priority order
+    for (const fingerId of FINGER_PRIORITY_ORDER) {
+      const anchor = anchorPads.find(p => p.fingerId === fingerId);
+      if (anchor && anchor.row >= 0 && anchor.row <= 7) {
+        const key = cellKey(anchor.row, anchor.col);
+        // Only add if empty (not already assigned)
+        if (!activeMapping.cells[key] && !anchorPadKeys.has(key)) {
+          orderedPads.push({ row: anchor.row, col: anchor.col, key });
+          anchorPadKeys.add(key);
+        }
+      }
+    }
+    
+    // Add remaining empty pads (row-major order for determinism)
+    for (let row = 0; row < 8; row++) {
+      for (let col = 0; col < 8; col++) {
+        const key = cellKey(row, col);
+        if (!activeMapping.cells[key] && !anchorPadKeys.has(key)) {
+          orderedPads.push({ row, col, key });
+        }
+      }
+    }
+
+    if (orderedPads.length === 0) {
+      alert('No empty Pads available. All 64 Pads are already assigned.');
+      return;
+    }
+
+    // Map sorted voices to ordered pads (deterministic)
+    const assignments: Record<string, Voice> = {};
+    const maxAssignments = Math.min(sortedVoices.length, orderedPads.length);
+
+    for (let i = 0; i < maxAssignments; i++) {
+      assignments[orderedPads[i].key] = sortedVoices[i];
+    }
+
+    // Batch assign all at once and update layoutMode
+    if (Object.keys(assignments).length > 0) {
+      if (!activeMapping) {
+        const newMapping: GridMapping = {
+          id: `mapping-${Date.now()}`,
+          name: 'New Mapping',
+          cells: assignments,
+          fingerConstraints: {},
+          scoreCache: null,
+          notes: '',
+          layoutMode: 'manual', // Natural Pose is a form of manual/deterministic layout
+        };
+        setProjectState({
+          ...projectState,
+          mappings: [...projectState.mappings, newMapping],
+          activeMappingId: newMapping.id,
+        });
+      } else {
+        setProjectState({
+          ...projectState,
+          mappings: projectState.mappings.map(m => {
+            if (m.id !== activeMapping.id) return m;
+            return {
+              ...m,
+              cells: {
+                ...m.cells,
+                ...assignments,
+              },
+              layoutMode: 'manual',
+            };
+          }),
+        });
+      }
+
+      console.log(`[Workbench] Assign Natural Pose: placed ${Object.keys(assignments).length} voices deterministically.`);
+    }
+  };
+
+  // Check if Natural Pose is available
+  const pose0 = projectState.naturalHandPoses?.[0];
+  const hasNaturalPose = pose0 && poseHasAssignments(pose0);
+
+  // ============================================================================
   // EXPLICIT LAYOUT CONTROL: Clear Grid
   // ============================================================================
   // Removes all pad assignments and moves sounds back to staging.
@@ -1173,40 +1314,58 @@ export const Workbench: React.FC = () => {
 
               <div className="h-6 w-px bg-slate-700/50" />
 
-              {/* Assign Randomly Button */}
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleAutoAssignRandom}
-                disabled={!activeMapping || projectState.parkedSounds.filter(s => !Object.values(activeMapping.cells).some(c => c.id === s.id)).length === 0}
-                title="Randomly assign unassigned sounds to empty pads"
-                leftIcon={(
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                  </svg>
-                )}
-              >
-                Randomize
-              </Button>
+              {/* Primary layout: Natural (assign to pose pads) then Auto-Arrange (optimize). Random is secondary. */}
+              <div className="flex items-center gap-1.5">
+                {/* Natural: assign sounds to Natural Hand Pose pads first (primary when pose is set) */}
+                <Button
+                  variant={hasNaturalPose ? "primary" : "secondary"}
+                  size="sm"
+                  onClick={handleAutoAssignNaturalPose}
+                  disabled={!activeMapping || !hasNaturalPose || projectState.parkedSounds.filter(s => !Object.values(activeMapping.cells).some(c => c.id === s.id)).length === 0}
+                  title={hasNaturalPose ? "Assign sounds to your Natural Hand Pose pads first (by importance). Use this to fill the grid from the library." : "Set your Natural Hand Pose in the Pose tab first, then use this to assign sounds to those pads."}
+                  leftIcon={(
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11" />
+                    </svg>
+                  )}
+                >
+                  Natural
+                </Button>
 
-              <div className="h-6 w-px bg-slate-700/50" />
+                {/* Auto-Arrange: optimize layout (respects Natural Hand Pose when set) */}
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleOptimizeLayout}
+                  disabled={isOptimizingLayout || !activeMapping || !filteredPerformance || filteredPerformance.events.length === 0 || Object.keys(activeMapping?.cells || {}).length === 0}
+                  isLoading={isOptimizingLayout}
+                  title={hasNaturalPose ? "Optimize pad layout; prefers your Natural Hand Pose positions" : "Optimize pad layout using Simulated Annealing"}
+                  leftIcon={!isOptimizingLayout && (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                  )}
+                >
+                  {isOptimizingLayout ? 'Optimizing...' : 'Auto-Arrange'}
+                </Button>
 
-              {/* Auto-Arrange Grid Button (Simulated Annealing) */}
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleOptimizeLayout}
-                disabled={isOptimizingLayout || !activeMapping || !filteredPerformance || filteredPerformance.events.length === 0 || Object.keys(activeMapping?.cells || {}).length === 0}
-                isLoading={isOptimizingLayout}
-                title="Optimize pad layout using Simulated Annealing"
-                leftIcon={!isOptimizingLayout && (
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                  </svg>
-                )}
-              >
-                {isOptimizingLayout ? 'Optimizing...' : 'Auto-Arrange'}
-              </Button>
+                {/* Random: secondary option */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleAutoAssignRandom}
+                  disabled={!activeMapping || projectState.parkedSounds.filter(s => !Object.values(activeMapping.cells).some(c => c.id === s.id)).length === 0}
+                  title="Randomly assign unassigned sounds to empty pads (secondary option)"
+                  className="text-slate-400 hover:text-slate-200"
+                  leftIcon={(
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                  )}
+                >
+                  Random
+                </Button>
+              </div>
 
               <div className="h-6 w-px bg-slate-700/50" />
 


### PR DESCRIPTION
## Summary

Replace hand pose import/export with a built-in default pose. Users can edit the pose via the finger palette; the app ships with sensible cell positions and offset logic out of the box.

## Changes

### Built-in default pose (`src/types/naturalHandPose.ts`)
- `createDefaultPose0()` now returns a pose with all 10 fingers assigned:
  - **Left hand:** Thumb (0,3), Index (3,3), Middle (4,2), Ring (4,1), Pinky (4,0)
  - **Right hand:** Thumb (0,4), Index (3,4), Middle (4,5), Ring (4,6), Pinky (4,7)
- Added `createEmptyPose0()` for tests and explicit empty-pose scenarios
- Offset logic (`getPose0PadsWithOffset`, `getMaxSafeOffset`, etc.) unchanged

### Natural Hand Pose panel (`src/workbench/NaturalHandPosePanel.tsx`)
- Removed Import, Export, Copy, and Paste buttons and handlers
- Panel now supports editing only via the finger palette
- Updated header comment to reflect built-in pose workflow

### Tests (`src/types/__tests__/naturalHandPose.test.ts`)
- Tests that expect empty pose now use `createEmptyPose0()`
- `createPoseWithPads` uses `createEmptyPose0()` for partial-pose tests
- All 40 tests passing

## Rationale

- No external JSON files needed; pose is configured in-app
- Offset logic remains built-in; users can still preview vertical shifts
- Edit flow simplified: click finger → click pad to assign

Made-with: Cursor