### PR TITLE
Add first-draft product synthesis package

### DIFF
--- a/docs/product-synthesis/ARTIFACT_INPUTS_CHECKLIST.md
+++ b/docs/product-synthesis/ARTIFACT_INPUTS_CHECKLIST.md
@@ -1,0 +1,267 @@
+# Artifact Inputs Checklist
+
+## Purpose
+
+This checklist answers:
+
+"What information do we now have that is sufficient to draft missing product artifacts, and what information is still missing or ambiguous?"
+
+It is organized by the next product-definition artifacts that a human + LLM workflow would likely create.
+
+## Inputs for a User Mission
+
+### Successfully extracted
+
+- Core product purpose:
+  - analyze Push playability and help author ergonomic mappings
+- Primary environment:
+  - Ableton Push-style 8x8 drum-pad workflow
+- Core user action:
+  - map imported MIDI pitches to pads
+- Core value:
+  - lower physical difficulty and understand why difficulty occurs
+
+### Still unclear
+
+- Whether the mission should frame the product as:
+  - a performance workstation
+  - a personalized ergonomics assistant
+  - a song portfolio tool
+- Whether practice and learning are part of the core mission or supporting outcomes
+
+### Human decisions needed
+
+- Choose the primary mission statement.
+- Decide whether personalization is central or optional.
+
+## Inputs for Core User Goals
+
+### Successfully extracted
+
+- Manage songs and attach MIDI
+- Configure natural hand pose
+- author or auto-generate mappings
+- analyze playability
+- optimize mappings
+- inspect transitions and timing
+
+### Still unclear
+
+- Which goals are first-class versus advanced/power-user only
+- Whether multi-mapping comparison is a core user goal or an expert feature
+
+### Human decisions needed
+
+- Rank user goals by importance.
+- Decide which ones are headline goals in future UX specs.
+
+## Inputs for JTBD
+
+### Successfully extracted
+
+- performance-to-mapping job
+- explanation / diagnosis job
+- personalization job
+- iterative optimization job
+
+### Still unclear
+
+- Whether practice / rehearsal deserves its own core JTBD
+- Whether portfolio organization is truly part of the user's desired outcome
+
+### Human decisions needed
+
+- Finalize 1-3 primary JTBD statements.
+- Decide whether a "practice" JTBD belongs in the core set or later roadmap.
+
+## Inputs for Workflow Maps
+
+### Successfully extracted
+
+- Dashboard -> link MIDI -> Workbench
+- Pose setup workflow
+- manual authoring workflow
+- auto-seed / natural / random / quadrant workflows
+- run analysis workflow
+- optimize layout workflow
+- timeline inspection workflow
+- event-analysis workflow
+- save/load/export workflow
+
+### Still unclear
+
+- The preferred or recommended default route through these workflows
+- The intended stopping points and branch rules between helper actions
+
+### Human decisions needed
+
+- Choose the canonical first-run flow.
+- Decide which workflows are primary, secondary, advanced, or debug-only.
+
+## Inputs for Screen Architecture
+
+### Successfully extracted
+
+- All current routes and their active purposes
+- Major panels in Workbench, Timeline, Event Analysis, and Cost Debug
+- Current navigation hierarchy
+- Which screens are overloaded or duplicative
+
+### Still unclear
+
+- Which analysis route should be canonical
+- Whether Timeline is a core screen or supporting screen
+- Whether Cost Debug should remain an internal-only artifact forever
+
+### Human decisions needed
+
+- Define final screen hierarchy.
+- Decide which screens are first-class, drill-down, or internal.
+
+## Inputs for Task-Based UX Specs
+
+### Successfully extracted
+
+- concrete task inventory
+- prerequisites and success conditions
+- current failure/confusion points
+- major decisions users currently have to make
+
+### Still unclear
+
+- Acceptable failure states and recovery patterns for the core flows
+- Desired onboarding / helper text / empty-state behavior
+
+### Human decisions needed
+
+- Decide the intended user guidance model.
+- Define task success criteria from a user perspective, not just system behavior.
+
+## Inputs for Wireframes / Mockups
+
+### Successfully extracted
+
+- current page map
+- current panel map
+- current control inventory
+- overloaded and duplicated concepts
+- missing feedback loops
+
+### Still unclear
+
+- What the ideal information hierarchy should be
+- Which controls should be primary vs tucked away
+- Whether pose setup should be integrated earlier or kept as a side panel
+
+### Human decisions needed
+
+- Decide the desired interaction hierarchy before any visual redesign.
+- Decide whether to optimize for guided flow, expert density, or progressive disclosure.
+
+## Inputs for a Terminology Canon
+
+### Successfully extracted
+
+- current canonical-ish code terms:
+  - song
+  - performance
+  - voice
+  - pad
+  - mapping
+  - natural hand pose
+  - solver result
+- known overloaded or conflicting terms:
+  - layout
+  - assignment
+  - analysis
+  - sound
+  - section
+
+### Still unclear
+
+- Final user-facing naming for:
+  - mapping vs layout
+  - solver result vs analysis result
+  - pose vs neutral/resting pose
+
+### Human decisions needed
+
+- Approve a final terminology canon.
+- Decide which legacy terms should be retired from product copy.
+
+## Inputs for a Source-of-Truth Domain Model
+
+### Successfully extracted
+
+- `Song` as portfolio container
+- `ProjectState` as main product-state container
+- `Performance` as musical input
+- `GridMapping` as editable placement artifact
+- `NaturalHandPose` as personalization artifact
+- `EngineResult` as derived analysis artifact
+
+### Still unclear
+
+- Whether `LayoutSnapshot` remains a distinct user-facing concept or just an internal performance wrapper
+- Whether `sectionMaps` remain part of the product domain
+- Whether templates should become canonical product objects
+
+### Human decisions needed
+
+- Freeze the canonical user-facing domain model.
+- Decide which dormant objects remain in scope.
+
+## Inputs for Acceptance Criteria / QA
+
+### Successfully extracted
+
+- active routes and current intended behaviors
+- key invariants:
+  - empty-grid import
+  - 8x8 grid
+  - full coverage before optimization
+  - Pose 0 uniqueness constraints
+  - filtered vs raw performance distinction
+- current verification baseline:
+  - build failing on 2026-03-13
+  - tests failing on 2026-03-13
+
+### Still unclear
+
+- Which current failures are acceptable transitional drift versus true behavioral regressions
+- What user-level acceptance criteria should be for:
+  - mapping creation
+  - optimization success
+  - analysis consistency across routes
+
+### Human decisions needed
+
+- Define acceptance criteria from product intent, not just current implementation.
+- Decide which current regressions block future design work and which can be deferred.
+
+## Overall Sufficiency Assessment
+
+### What we now have enough information to draft
+
+- Product overview
+- feature inventory
+- user goals and JTBD
+- workflow maps
+- screen architecture
+- terminology canon draft
+- domain source-of-truth draft
+- task-based UX-spec draft
+- QA checklist draft
+
+### What remains materially ambiguous
+
+- primary mission framing
+- primary workflow order
+- role of Pose 0 in onboarding
+- role of Timeline and Event Analysis relative to Workbench
+- role of sections, templates, and practice-mode concepts
+
+### Bottom line
+
+The repo now yields enough evidence to author the next-generation product-definition artifacts, but not enough to finalize them without human judgment on hierarchy, scope, and terminology.
+

--- a/docs/product-synthesis/CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md
+++ b/docs/product-synthesis/CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md
@@ -1,0 +1,143 @@
+# Constraints, Constants, and Invariants
+
+## Scope
+
+This document captures product-relevant rules and tunables that materially affect behavior. It includes explicit constants from engine code, workflow constraints enforced in UI logic, and invariants that the system appears to rely on.
+
+## Product Constraints
+
+| Name | Description | Where defined or enforced | Enforced consistently? | Risks if violated |
+|---|---|---|---|---|
+| Explicit empty-grid import model | MIDI import creates an empty grid and puts all voices in staging | `src/utils/midiImport.ts`, `src/services/SongService.ts:createProjectStateFromMidi`, `docs/MilestoneNotes/2025-11-29-explicit-layout-model.md` | Yes in current import path | Users or future code may assume import should auto-map voices |
+| Song-specific local persistence | Each song points to one project-state blob in localStorage | `src/services/SongService.ts`, `src/utils/projectPersistence.ts` | Yes | Confusion if users expect cloud sync or shared project states |
+| Optimization requires full coverage | Auto-arrange is blocked if the current mapping does not cover all notes used in the performance | `src/workbench/Workbench.tsx`, `src/engine/mappingCoverage.ts` | Yes in current UI path | Optimization results would be misleading or invalid with unmapped notes |
+| Pose-aware workflows assume Pose 0 exists | Natural assignment and pose-driven seed require a valid pose | `src/workbench/Workbench.tsx`, `src/context/ProjectContext.tsx`, `src/types/naturalHandPose.ts` | Yes | User may not understand why pose-less flows are weaker or blocked |
+| Dev-only debug route | Cost Debug should only be available in development builds | `src/main.tsx`, `src/pages/CostDebugPage.tsx` | Yes | Production UX would expose internal debug concepts |
+
+## Domain Constraints
+
+| Name | Description | Where defined or enforced | Enforced consistently? | Risks if violated |
+|---|---|---|---|---|
+| 8x8 pad grid | The physical grid model is fixed to 8 rows and 8 columns | `src/types/performance.ts:InstrumentConfig`, `src/engine/gridMapService.ts`, grid rendering code | Yes | Most layout, mapping, and visualization logic assumes 64 pads |
+| Only `drum_64` mode is active | Instrument config currently supports only `drum_64` | `src/types/performance.ts` | Yes | Future layout modes would break assumptions across engine and UI |
+| Row indexing convention | Row 0 is bottom, row 7 is top; col 0 is left | `src/types/layout.ts`, `src/types/naturalHandPose.ts`, UI comments | Yes | Misread orientation would corrupt pose, mapping, and reach logic |
+| Performance must be time-sorted | `Performance.events` must be sorted by `startTime` ascending | `src/types/performance.ts`, `src/utils/midiImport.ts` | Mostly yes | Grouping, timeline, and solver assumptions would drift |
+| Note identity for mapping coverage | Coverage is keyed by `noteNumber` only, channel ignored | `src/engine/mappingCoverage.ts` | Yes | Multi-channel semantics could be collapsed unintentionally |
+| Strict note-to-pad resolution can return unmapped | In strict mode, notes absent from mapping remain unmapped | `src/engine/mappingResolver.ts` | Yes | Optimization or analysis could silently fall back when it should not |
+| Finger-lock values | Finger locks are encoded as `L1-L5` or `R1-R5` strings | `src/workbench/LayoutDesigner.tsx`, `src/types/layout.ts` | Yes | Invalid constraint strings would break pad-lock meaning |
+| Pose uniqueness | No two fingers may occupy the same pad in a valid `NaturalHandPose` | `src/types/naturalHandPose.ts:validateNaturalHandPose` | Yes | Pose-based seeding and neutral overrides become ambiguous |
+
+## Technical Constraints
+
+| Name | Description | Where defined or enforced | Enforced consistently? | Risks if violated |
+|---|---|---|---|---|
+| LocalStorage storage model | Songs live under `push_perf_songs`; project states under `push_perf_project_<id>` | `src/services/SongService.ts`, `src/utils/projectPersistence.ts` | Yes | Data loss or orphaning if keys change |
+| Theme storage | Theme stored under `push_perf_theme` | `src/context/ThemeContext.tsx` | Yes | Theme resets or inconsistent shell state |
+| Workbench autosave debounce | Project state autosaves after 1 second | `src/workbench/Workbench.tsx` | Yes | Excess writes if shortened too much; lost changes if removed |
+| Undo history cap | Undo history retains up to 50 states | `src/hooks/useProjectHistory.ts` | Yes | Too low loses useful history; too high may inflate memory |
+| Practice-loop speed options | Fixed loop speeds: `0.75`, `0.85`, `1.0`, `1.10` | `src/workbench/PracticeLoopControls.tsx`, `src/workbench/EventAnalysisPanel.tsx` | Yes | Exported loop config and UI expectations diverge if changed casually |
+| Practice-loop timer clamp | Loop interval is clamped between `50ms` and `2000ms` | `src/hooks/usePracticeLoop.ts` | Yes | Extremely fast or slow transitions would become unusable |
+| Hydration current-song key | Current song tracking stored under `push_perf_current_song_id` | `src/hooks/useSongStateHydration.ts` | Yes | Route re-entry logic may misbehave if altered |
+
+## Constants and Tunables
+
+### Engine constants
+
+| Constant | Value | Meaning | Source |
+|---|---|---|---|
+| `maxSpan` | `4` | nominal maximum span width in grid cells | `src/engine/models.ts` |
+| `minSpan` | `0` | nominal minimum span | `src/engine/models.ts` |
+| `idealReach` | `2` | comfortable reach target | `src/engine/models.ts` |
+| `maxReach` | `4` | max reach before movement becomes impossible | `src/engine/models.ts` |
+| `activationCost` | `5.0` | cost of activating an unplaced finger | `src/engine/models.ts` |
+| `crossoverPenaltyWeight` | `20.0` | penalty weight for finger crossover | `src/engine/models.ts` |
+| `fatigueRecoveryRate` | `0.5` | fatigue recovery per second | `src/engine/models.ts` |
+
+### Finger-strength weights
+
+| Finger | Weight | Source |
+|---|---|---|
+| index | `1.0` | `src/engine/models.ts` |
+| middle | `1.0` | `src/engine/models.ts` |
+| ring | `1.1` | `src/engine/models.ts` |
+| pinky | `2.5` | `src/engine/models.ts` |
+| thumb | `2.0` | `src/engine/models.ts` |
+
+### Movement / cost-function constants
+
+| Constant | Value | Meaning | Source |
+|---|---|---|---|
+| `MAX_HAND_SPEED` | `12.0` | assumed physiological max hand speed in grid units per second | `src/engine/costFunction.ts` |
+| `SPEED_COST_WEIGHT` | `0.5` | weight for speed component in transition cost | `src/engine/costFunction.ts` |
+| `FALLBACK_GRIP_PENALTY` | `1000` | huge penalty for fallback grips that ignore constraints | `src/engine/costFunction.ts` |
+| `ALTERNATION_DT_THRESHOLD` | `0.25` | same-finger repetition threshold in seconds | `src/engine/costFunction.ts` |
+| `ALTERNATION_PENALTY` | `1.5` | base same-finger repetition penalty | `src/engine/costFunction.ts` |
+| `HAND_BALANCE_TARGET_LEFT` | `0.45` | target left-hand share | `src/engine/costFunction.ts` |
+| `HAND_BALANCE_WEIGHT` | `2.0` | weight for hand-balance penalty | `src/engine/costFunction.ts` |
+| `HAND_BALANCE_MIN_NOTES` | `2` | minimum notes before hand-balance penalty applies | `src/engine/costFunction.ts` |
+
+### Feasibility constants
+
+| Constant | Value | Meaning | Source |
+|---|---|---|---|
+| `MAX_FINGER_SPAN_STRICT` | `5.5` | strict max distance between active fingers | `src/engine/feasibility.ts` |
+| `MAX_FINGER_SPAN_RELAXED` | `7.5` | relaxed max span for difficult chords | `src/engine/feasibility.ts` |
+| `THUMB_DELTA` | `1.0` | strict thumb positional tolerance | `src/engine/feasibility.ts` |
+| `THUMB_DELTA_RELAXED` | `2.0` | relaxed thumb positional tolerance | `src/engine/feasibility.ts` |
+| reachability green threshold | `<= 3.0` | easy reach in ghost-hand map | `src/engine/feasibility.ts:getReachabilityMap` |
+
+### Event-analysis constants
+
+| Constant | Value | Meaning | Source |
+|---|---|---|---|
+| `EVENT_TIME_EPSILON` | `1e-4` seconds | simultaneity grouping tolerance | `src/engine/eventMetrics.ts` |
+| left-hand event home | `{row:0,col:1}` | event-stretch fallback home | `src/engine/eventMetrics.ts` |
+| right-hand event home | `{row:0,col:5}` | event-stretch fallback home | `src/engine/eventMetrics.ts` |
+| `MAX_REACH_DISTANCE` | `4.0` | max allowed finger-move distance in onion-skin movement model | `src/engine/onionSkinBuilder.ts` |
+
+### Transition-difficulty weighting
+
+| Factor | Weight / impact | Source |
+|---|---|---|
+| speed pressure | `60%` of base score | `src/engine/transitionAnalyzer.ts` |
+| anatomical stretch | `30%` of base score | `src/engine/transitionAnalyzer.ts` |
+| normalized distance | `10%` of base score | `src/engine/transitionAnalyzer.ts` |
+| hand switch | `+0.15` | `src/engine/transitionAnalyzer.ts` |
+| finger change | `+0.1` | `src/engine/transitionAnalyzer.ts` |
+
+### UI and workflow enumerations
+
+| Enumeration / range | Values | Source |
+|---|---|---|
+| layout modes | `manual`, `optimized`, `random`, `auto`, `none` | `src/types/layout.ts` |
+| library tabs | `Detected`, `Unassigned`, `Placed` | `src/workbench/VoiceLibrary.tsx` |
+| Workbench left tabs | `Library`, `Pose` | `src/workbench/LayoutDesigner.tsx` |
+| analysis tabs | `summary`, `comparison`, `optimization` | `src/workbench/AnalysisPanel.tsx` |
+| event-analysis left tabs | `timeline`, `log` | `src/workbench/EventAnalysisPanel.tsx` |
+| timeline zoom slider | `10` to `500` pixels per second | `src/pages/TimelinePage.tsx` |
+| pose preview offset | `-4` to `+4` rows | `src/workbench/NaturalHandPosePanel.tsx`, `src/types/naturalHandPose.ts` |
+| undo history size | `50` states | `src/hooks/useProjectHistory.ts` |
+
+## Invariants
+
+| Invariant | Description | Where implied or enforced | Enforced consistently? | Risks if violated |
+|---|---|---|---|---|
+| `ProjectState.activeMappingId` should identify the mapping used across routes | Workbench, Timeline, and Event Analysis should resolve the same active mapping | `src/workbench/Workbench.tsx`, `src/pages/TimelinePage.tsx`, `src/context/ProjectContext.tsx` | Mostly yes in current code | Cross-route disagreement about what is being analyzed |
+| `manualAssignments` should key by stable event identity | Newer flows use `eventKey`, with fallback to index string when missing | `src/types/projectState.ts`, `src/workbench/EventLogTable.tsx` | Mostly yes, but fallback remains | Wrong assignment may attach to wrong event under drift conditions |
+| `naturalHandPoses[0]` is Pose 0 | Index `0` is treated as the default personalized pose | `src/types/projectState.ts`, `src/context/ProjectContext.tsx` | Yes | Pose-dependent workflows break if index ordering changes |
+| Imported project state should always contain at least one default pose if poses are missing | Validation and import paths backfill default pose | `src/services/SongService.ts`, `src/utils/projectPersistence.ts` | Yes | Pose-driven features encounter null paths |
+| Filtered active performance excludes ignored notes only | Ignoring a note should not mutate raw stored performance | `src/utils/performanceSelectors.ts` | Yes | Destructive deletion and temporary hiding would be conflated |
+| `GridMapping.cells` keys are always `"row,col"` | Used everywhere for pads | `src/types/layout.ts`, Workbench, event analysis | Yes | Parsing and visualization fail if key shape changes |
+| Project JSON load should reject malformed core shape | Strict file load should fail fast | `src/utils/projectPersistence.ts:validateProjectStrict` | Intended yes | Bad imports can poison global state |
+
+## Constraint and Invariant Risks Worth Carrying Forward
+
+1. Product behavior depends heavily on exact indexing and identity conventions.
+   - `eventKey`, `row,col`, and `activeMappingId` are important coordination glue.
+
+2. Full-coverage optimization is a major product rule.
+   - Any future UX redesign should surface it before users hit a blocking alert.
+
+3. The product is physically opinionated.
+   - Constants such as reach limits, hand-balance targets, stretch weights, and fallback penalties are not minor implementation details; they are part of the product definition.
+

--- a/docs/product-synthesis/DOMAIN_MODEL_AND_TERMINOLOGY.md
+++ b/docs/product-synthesis/DOMAIN_MODEL_AND_TERMINOLOGY.md
@@ -1,0 +1,202 @@
+# Domain Model and Terminology
+
+## Why This Document Matters
+
+The repo has clearly been trying to standardize terminology, but current product language is still mixed across older docs, active code, UI labels, and historical artifacts. This document captures a first-pass canon based on current code truth, then calls out where meaning still drifts.
+
+## Terminology Glossary
+
+| Term | Definition as implied by the repo | Where it is used | Consistency | Related / overlapping terms |
+|---|---|---|---|---|
+| Song | A portfolio-level container for metadata, linked MIDI, and a pointer to project state | `src/types/song.ts`, Dashboard, `SongService` | Mostly consistent | performance, project |
+| Song metadata | Human-facing info about the song such as title, BPM, rating, tags | `src/types/song.ts`, Dashboard UI | Consistent | practice metrics, portfolio |
+| Performance | The time-ordered note-event sequence to analyze | `src/types/performance.ts`, engine, Event Analysis, Timeline | Strongly consistent | song, layout snapshot |
+| Note event | A single occurrence of a note number at a specific time | `src/types/performance.ts:NoteEvent` | Consistent | voice |
+| `eventKey` | Deterministic stable identity for an event based on timing, note, channel, and ordinal | `src/utils/midiImport.ts`, manual-assignment flows | Consistent in newer code | event index |
+| Voice | A unique MIDI pitch extracted from a performance and made assignable to a pad | `src/types/layout.ts`, `src/utils/midiImport.ts`, Workbench | Improved, but still mixed in comments/UI | sound, note, cell |
+| Sound | Usually a legacy or UI-friendly name for a voice; often still used in prop/function names | many Workbench component names and handlers | Inconsistent | voice |
+| Cell | An abstract slot in the drum-rack / note-number sense, not a physical pad | `docs/TERMINOLOGY.md`, some comments | Conceptually defined, but not always used consistently in active code | pad, note |
+| Pad | A physical grid location on the 8x8 surface, usually addressed as `row,col` | `src/types/layout.ts`, `src/types/eventAnalysis.ts`, grid UI | Consistent | cell |
+| Assignment | Mapping a voice to a pad, or assigning a finger to an event, depending on context | many files | Overloaded | mapping, finger assignment, manual assignment |
+| Layout snapshot | A saved container for a `Performance` plus metadata like name and createdAt | `src/types/projectState.ts:LayoutSnapshot` | Technically consistent, product meaning is weak | layout, mapping |
+| Grid mapping | The current note/voice-to-pad placement plus finger locks and notes | `src/types/layout.ts:GridMapping` | Strongly consistent in code | layout |
+| Layout mode | A label explaining how a mapping came to exist or change (`manual`, `random`, `optimized`, `auto`, `none`) | `src/types/layout.ts`, Workbench | Consistent | mapping origin |
+| Layout | Used ambiguously in product copy. Sometimes means `LayoutSnapshot`, sometimes `GridMapping`, sometimes the whole arrangement idea | headers, docs, comments | Inconsistent | mapping, project, section |
+| Instrument config | The Push grid configuration, especially bottom-left note and supported mode | `src/types/performance.ts:InstrumentConfig` | Consistent | grid window |
+| Natural hand pose / Pose 0 | User-defined finger resting positions on the pad grid | `src/types/naturalHandPose.ts`, Workbench Pose tab | Strongly consistent | neutral pose, resting pose |
+| Resting pose | Engine-level left/right hand home geometry used in configuration | `src/types/performance.ts:RestingPose`, `src/types/projectState.ts` | Consistent technically, but overlaps conceptually with Pose 0 | neutral pose |
+| Neutral pose / neutral pad positions | Solver-facing conversion of hand-pose assumptions into pad coordinates | `src/engine/handPose.ts` | Consistent in engine code | Pose 0, resting pose |
+| Manual assignment | Explicit user override for hand/finger on an event | `ProjectState.manualAssignments`, Event Log | Consistent in newer code | finger assignment |
+| Finger assignment | Which hand/finger plays an event or note | grid overlay, tables, event log, timeline labels | Consistent concept, many visual forms | manual assignment |
+| Engine result | The analysis result currently being visualized | `src/context/ProjectContext.tsx`, pages/panels | Mostly consistent | solver result |
+| Solver result | Stored result for a specific solver family such as beam, genetic, or annealing | `ProjectState.solverResults` | Consistent | engine result |
+| Debug event | Per-event analysis record from the engine including cost, difficulty, row/col, hand, and finger | `src/engine/core.ts`, Event Log, Cost Debug | Consistent | note event |
+| Analyzed event | A grouped simultaneous moment built from debug events | `src/types/eventAnalysis.ts`, Event Analysis page | Consistent in current code, but tests still show older expectations | event, debug event |
+| Transition | The movement relationship between two consecutive analyzed events | `src/types/eventAnalysis.ts`, Event Analysis page | Consistent | event |
+| Onion skin | A visualization model showing current/previous/next pads and finger moves | `src/types/eventAnalysis.ts`, `src/engine/onionSkinBuilder.ts` | Consistent in current code | event analysis |
+| Workbench | The main routed editing environment | `src/workbench/Workbench.tsx` | Consistent | editor |
+| Timeline | Chronological event visualization for a mapped performance | `src/pages/TimelinePage.tsx` | Consistent | practice, event analysis |
+| Optimization | Rearranging the pad mapping to reduce ergonomic cost | `optimizeLayout`, annealing surfaces | Mostly consistent | solver run, auto-arrange |
+| Analysis | Evaluating playability and visualizing it | many routes and components | Broad and overloaded | solver run, optimization |
+| Constraint | A hard or soft rule affecting movement feasibility or user-imposed finger usage | engine feasibility, finger locks | Consistent | cost, lock |
+| Cost | Numeric penalty from one or more ergonomic factors | engine models, cost debug, analysis panel | Consistent | score, difficulty |
+| Score / ergonomic score | High-level result communicated to users from accumulated cost outcomes | Analysis panel, Event Analysis header | Mostly consistent | cost |
+| Section map | A time-based mapping structure for song sections | `src/types/performance.ts`, `ProjectState.sectionMaps` | Dormant / unclear | section, song |
+| Template | Predefined suggested pad assignment scheme | `src/types/layout.ts` | Hidden / unclear | standard kit |
+
+## Domain Objects
+
+### Core durable product objects
+
+| Object | What it represents | Key fields | Canonical / derived / transient |
+|---|---|---|---|
+| `Song` | Portfolio container for a user's saved work | `metadata`, `projectStateId`, `midiData`, `midiFileName`, `sections` | canonical durable object |
+| `SongMetadata` | Dashboard-facing descriptive fields | `title`, `bpm`, `key`, `performanceRating`, `tags` | canonical durable sub-object |
+| `ProjectState` | Main persisted workbench state for a song | `layouts`, `mappings`, `parkedSounds`, `manualAssignments`, `solverResults`, `naturalHandPoses`, `activeMappingId` | canonical durable object |
+| `LayoutSnapshot` | Named performance snapshot inside project state | `id`, `name`, `performance`, `createdAt` | canonical durable object |
+| `GridMapping` | Voice-to-pad placement and mapping metadata | `cells`, `fingerConstraints`, `layoutMode`, `scoreCache`, `version`, `savedAt` | canonical durable object |
+| `Voice` | One assignable unique MIDI pitch | `id`, `name`, `originalMidiNote`, `color`, `sourceType` | canonical durable object |
+| `InstrumentConfig` | The active grid-note mapping basis | `bottomLeftNote`, `rows`, `cols`, `layoutMode` | canonical durable object |
+| `NaturalHandPose` | User-specific finger resting positions | `fingerToPad`, `positionIndex`, `maxUpShiftRows` | canonical durable object |
+
+### Core computed analysis objects
+
+| Object | What it represents | Key fields | Canonical / derived / transient |
+|---|---|---|---|
+| `EngineResult` | Solver output for a particular mapping/performance combination | `score`, `debugEvents`, `averageMetrics`, `fatigueMap`, `hardCount`, `unplayableCount` | derived but persisted in `ProjectState.solverResults` |
+| `EngineDebugEvent` | Per-note or per-trigger analysis output | `noteNumber`, `startTime`, `assignedHand`, `finger`, `row`, `col`, `cost`, `costBreakdown` | derived |
+| `AnalyzedEvent` | Grouped simultaneous moment derived from debug events | `eventIndex`, `timestamp`, `notes`, `pads`, `eventMetrics` | derived transient UI model |
+| `Transition` | Relationship between two consecutive analyzed events | `fromIndex`, `toIndex`, `metrics` | derived transient UI model |
+| `OnionSkinModel` | Focused event-analysis visualization model | `currentEvent`, `previousEvent`, `nextEvent`, `sharedPads`, `fingerMoves` | derived transient UI model |
+| `MappingCoverageResult` | Whether a mapping covers the notes in a performance | `unmappedNotes`, `mappedNotes`, `mappedEventCount` | derived transient validation model |
+
+### Important transient UI state
+
+| State | What it represents | Where it lives |
+|---|---|---|
+| `activeMappingId` | Which mapping is being viewed/edited across routes | `ProjectState.activeMappingId` |
+| `selectedEventIndex` | Which analyzed event / transition is focused in Event Analysis | `src/workbench/EventAnalysisPanel.tsx` |
+| `ignoredNoteNumbers` | Which voices are hidden from filtered performance | `ProjectState.ignoredNoteNumbers` |
+| `showNoteLabels`, `showPositionLabels`, `showHeatmap` | Workbench view toggles | local state in `Workbench` |
+| `theme` | current theme mode | `ThemeContext` |
+
+## Relationship Map
+
+```text
+Song
+  -> projectStateId
+  -> SongMetadata
+  -> optional MIDI payload
+
+ProjectState
+  -> LayoutSnapshot[] (contains Performance)
+  -> GridMapping[] (contains pad assignments)
+  -> Voice[] parkedSounds
+  -> manualAssignments[layoutId][eventKey]
+  -> solverResults[solverId]
+  -> NaturalHandPose[] (Pose 0 at index 0)
+  -> activeLayoutId / activeMappingId
+
+Performance
+  -> NoteEvent[]
+  -> tempo / name
+
+GridMapping
+  -> cells["row,col"] = Voice
+  -> fingerConstraints["row,col"] = "L2" / "R4"
+
+EngineResult
+  -> debugEvents[]
+  -> score / counts / average metrics
+
+Event Analysis
+  EngineResult.debugEvents
+    -> AnalyzedEvent[]
+    -> Transition[]
+    -> OnionSkinModel
+```
+
+## Canonical vs Derived vs Dormant
+
+### Likely canonical concepts
+
+- `Song`
+- `ProjectState`
+- `Performance`
+- `GridMapping`
+- `Voice`
+- `NaturalHandPose`
+- `EngineResult` per solver
+
+### Derived concepts
+
+- ergonomic score
+- cost breakdown
+- grouped analyzed events
+- transitions
+- onion-skin model
+- coverage metrics
+
+### Dormant or weakly canonical concepts
+
+- `sectionMaps`
+- layout templates
+- song `sections`
+- some historical "AnalysisView" architecture mentioned in older docs/audit notes
+
+## Terminology Problems
+
+### Overloaded terms
+
+| Term | Problem | Examples |
+|---|---|---|
+| layout | Can mean performance snapshot, pad mapping, generated arrangement, or workflow stage | `LayoutSnapshot`, `GridMapping`, header copy, layout mode |
+| assignment | Can mean voice-to-pad assignment, finger-to-event assignment, or finger-lock constraint | `GridMapping.cells`, `manualAssignments`, context-menu finger locks |
+| analysis | Can mean solver execution, summary visualization, event drill-down, or debug inspection | Workbench, Event Analysis, Cost Debug |
+
+### Synonyms for the same or near-same concept
+
+| Concept | Competing names |
+|---|---|
+| unique pitch object | `Voice`, `Sound`, sometimes `note` |
+| finger-hand notation | `left/right`, `L/R`, `LH/RH`, `L1/R2` |
+| preferred hand baseline | `Natural Hand Pose`, `Pose 0`, `neutral pose`, `resting pose` |
+
+### Concepts split across multiple names
+
+| Concept | Split names | Why it matters |
+|---|---|---|
+| the editable pad-placement artifact | `mapping`, `layout`, `Quadrant Layout`, `Optimized Layout`, `New Mapping` | Makes it hard to speak clearly about what exactly is being changed |
+| the time-based musical input | `song`, `performance`, `layout`, `section` | Top-level product framing gets blurry |
+
+### Terms whose meaning changes by page or subsystem
+
+| Term | Where meaning shifts |
+|---|---|
+| event | raw note event in engine/performance; grouped simultaneous moment in Event Analysis |
+| layout | mapping in Workbench UI; performance container in type names; section layout in header copy |
+| practice | route-level aspiration in historical docs; current visual stepper in Event Analysis; not a dedicated routed product flow |
+
+## First-Pass Terminology Canon Recommendation
+
+If the product were normalized around current code truth, the clearest working canon would likely be:
+
+- Song:
+  - the portfolio-level container
+- Performance:
+  - the imported time-ordered MIDI event data
+- Voice:
+  - one unique MIDI pitch extracted from that performance
+- Pad:
+  - one physical 8x8 coordinate
+- Mapping:
+  - the current voice-to-pad placement
+- Natural Hand Pose:
+  - the user's preferred finger resting arrangement on the grid
+- Analysis result:
+  - a solver output explaining the playability of a performance under a mapping
+- Optimization:
+  - a mapping rewrite intended to improve that analysis result
+
+That canon is not fully enforced in the current repo yet, but it best matches the current operational center of the application.
+

--- a/docs/product-synthesis/FEATURE_INVENTORY.md
+++ b/docs/product-synthesis/FEATURE_INVENTORY.md
@@ -1,0 +1,143 @@
+# Feature Inventory
+
+## Scope
+
+This inventory aims to capture the full current product surface implied by code and active documentation, including user-visible features, hidden code-only capabilities, incomplete flows, and features whose status is ambiguous.
+
+Status labels used here:
+
+- `implemented`: current code clearly supports it
+- `partial`: user can see or touch it, but the flow is incomplete or limited
+- `hidden`: implemented in code but not clearly surfaced in main UX
+- `duplicate`: available in more than one overlapping surface
+- `legacy/unclear`: present in code/docs but not clearly part of the active product
+- `broken-looking`: present, but current build/test state or obvious drift reduces confidence
+
+## Creation / Authoring
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Create empty song | creation / authoring | Adds a metadata-only song entry to the portfolio | Yes | `/` | `src/pages/Dashboard.tsx:handleAddSongClick`, `src/services/SongService.ts:createSong` | `Song`, `SongMetadata` | implemented | Dashboard add card calls `createSong('New Song', ...)` | Produces a song that immediately leads to "no MIDI" states until linked |
+| Seed default test song | creation / authoring | Ensures a bundled demo/test song exists | Mostly hidden | app bootstrap, `/` | `src/main.tsx:bootstrap`, `src/pages/Dashboard.tsx`, `src/services/SongService.ts:seedDefaultTestSong`, `src/data/testData.ts` | `Song`, base64 MIDI, `ProjectState` | implemented | Bootstrap and Dashboard both seed it | This quietly changes first-run product state |
+| Create project state from MIDI | creation / authoring | Converts MIDI into performance, voices, config, mapping, and pose defaults | Hidden | triggered from Dashboard link/re-link flow | `src/services/SongService.ts:createProjectStateFromMidi`, `src/utils/midiImport.ts` | `ProjectState`, `Performance`, `Voice[]`, `GridMapping`, `NaturalHandPose[]` | implemented | Current import path uses `linkMidiToSong` | Core creation step is not exposed as a named user concept |
+| Link MIDI to existing song | creation / authoring | Attaches a MIDI file to a song and rebuilds its project state | Yes | `/` | `src/components/dashboard/SongCard.tsx`, `src/pages/Dashboard.tsx:handleMidiLinked`, `src/services/SongService.ts:linkMidiToSong` | `Song`, `ProjectState`, `Performance` | implemented | Song card label triggers hidden file input | Re-link overwrites project state from MIDI, which may surprise users |
+| Import song directly from MIDI | creation / authoring | Create a brand-new song from a MIDI file in one step | Not in main UI | no current routed entry | `src/services/SongService.ts:importSongFromMidi` | `Song`, `ProjectState` | hidden | Method exists, but Dashboard no longer offers import CTA | Important capability exists but is not currently surfaced |
+
+## Editing / Layout Authoring
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Drag voice from library to grid | editing | Assign unplaced voice to pad by drag/drop | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx:handleDragEnd`, `src/workbench/VoiceLibrary.tsx` | `Voice`, `GridMapping.cells`, `parkedSounds` | implemented | DnD-kit workflow in LayoutDesigner | Main direct authoring interaction |
+| Move or swap placed voices | editing | Move a placed voice to another pad or swap with occupied pad | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx:handleDragEnd` | `GridMapping.cells`, `fingerConstraints` | implemented | Explicit swap logic preserves/moves constraints | Important for iterative layout tuning |
+| Unassign voice back to staging | editing | Drop placed voice into staging area to remove it from grid | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx`, `src/workbench/VoiceLibrary.tsx:DroppableStagingArea` | `GridMapping.cells`, `parkedSounds` | implemented | Drop target `staging-area` | User-facing language still mixes staging/library/unassigned |
+| Rename placed voice | editing | Double-click grid cell or placed list entry to rename | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx`, `src/workbench/VoiceLibrary.tsx:PlacedSoundItem` | `Voice.name` | implemented | Inline edit paths in both grid and placed list | Same concept appears in multiple places |
+| Rename / recolor staging voice | editing | Edit name and color from library list | Yes | `/workbench` | `src/workbench/VoiceLibrary.tsx:DraggableSound` | `Voice.name`, `Voice.color` | implemented | Library item edit panel | No centralized "voice details" model |
+| Delete voice from library and mappings | editing | Permanently remove a voice from staging and any mappings | Yes | `/workbench` | `src/workbench/VoiceLibrary.tsx`, `src/workbench/Workbench.tsx:handleDeleteSound` | `Voice`, `GridMapping.cells`, `parkedSounds` | implemented | Delete button confirmed with `window.confirm` | Destructive and strong; no undo-specific UX cue |
+| Clear staging area | editing | Delete all unassigned voices from staging | Yes | `/workbench` | `src/workbench/VoiceLibrary.tsx:handleClearStaging`, `src/workbench/LayoutDesigner.tsx` | `parkedSounds` | implemented | Button shown in Unassigned tab when non-empty | Destructive; effectively deletes voices rather than just hiding them |
+| Duplicate active mapping | editing | Create a copy of current mapping | Yes | `/workbench` settings | `src/workbench/Workbench.tsx:handleDuplicateMapping` | `GridMapping`, `activeMappingId` | implemented | Settings menu action | No explicit compare workflow after duplication |
+| Clear grid | editing | Remove all pad assignments and set layout mode to `none` | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleClearGrid` | `GridMapping.cells`, `layoutMode` | implemented | Toolbar action | Depends on parked voices still existing as references |
+| Organize by 4x4 banks | editing | Auto-place voices into quadrant-based regions | Yes | `/workbench` settings | `src/workbench/Workbench.tsx:handleMapToQuadrants`, `src/utils/autoLayout.ts` | `GridMapping`, `InstrumentConfig.bottomLeftNote` | implemented | Settings menu action | Product meaning of "quadrants" is not explained in UI |
+| Random assignment | editing | Randomly place unassigned voices on empty pads | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleAutoAssignRandom` | `GridMapping`, `parkedSounds`, `layoutMode='random'` | implemented | Toolbar button `Random` | Old docs called this "Assign Manually"; current label is clearer |
+| Finger locks on pads | editing | Constrain a pad to a specific finger/hand label | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx` context menu | `GridMapping.fingerConstraints` | implemented | Context menu allows `L1-L5` and `R1-R5` | Powerful but undiscoverable |
+| Remove sound via context menu | editing | Right-click a placed pad and remove its voice | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx` context menu | `GridMapping.cells` | implemented | Context menu `Remove Sound` | Duplicates drag-to-staging removal |
+| Hide voice from analysis/view | editing / filtering | Toggle note-number visibility without deleting it | Yes | `/workbench` | `src/workbench/VoiceLibrary.tsx`, `src/workbench/LayoutDesigner.tsx`, `src/utils/performanceSelectors.ts` | `ignoredNoteNumbers`, filtered `Performance` | implemented | Eye / hidden icon toggles | This is both an editing and analysis-scope feature |
+| Permanently delete all events for note | editing / filtering | Remove every event for a note number from the active performance | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx:handleDestructiveDelete`, `src/workbench/VoiceLibrary.tsx` | `LayoutSnapshot.performance.events` | implemented | Detected tab delete action | Very strong destructive action inside library list |
+
+## Pose / Personalization
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Edit Natural Hand Pose | personalization | Assign each finger to a preferred pad | Yes | `/workbench` | `src/workbench/NaturalHandPosePanel.tsx` | `NaturalHandPose`, `fingerToPad` | implemented | Dedicated Pose tab and editor | This is one of the clearest personalized features |
+| Pose keyboard shortcuts | personalization | Use `1-5` and `6-0` to choose fingers while editing pose | Yes | `/workbench` | `src/workbench/NaturalHandPosePanel.tsx` | `FingerId` | implemented | Keyboard handler in panel | Only available in edit mode |
+| Pose preview offset | personalization | Preview vertical shift of pose rows | Yes | `/workbench` | `src/workbench/NaturalHandPosePanel.tsx`, `src/types/naturalHandPose.ts` | `previewOffset`, `maxUpShiftRows` | implemented | Slider with safety messaging | Preview is visible, but exact product meaning is advanced |
+| Save and normalize pose | personalization | Save edited pose after normalization and validation | Yes | `/workbench` | `src/workbench/NaturalHandPosePanel.tsx`, `src/types/naturalHandPose.ts` | `NaturalHandPose` | implemented | `Save & Normalize Pose` button | Important system rule hidden in terminology, not broader product copy |
+| Pose ghost markers on grid | personalization / visualization | Show finger markers on pads during pose edit mode | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx`, `src/workbench/NaturalHandPosePanel.tsx:getPoseGhostMarkers` | `NaturalHandPose`, `PadCoord` | implemented | Ghost markers rendered in cells | Good bridge between pose and grid, but mode-specific |
+| Pose-driven seed mapping | personalization / optimization | Fill mapping deterministically from pose anchors and note importance | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleSeedFromPose0`, `src/engine/seedMappingFromPose0.ts` | `NaturalHandPose`, `Performance`, `GridMapping` | implemented | Toolbar button `Seed` | Returns mapping with `layoutMode: 'optimized'`, which is semantically odd for a seed operation |
+| Pose-driven natural assignment | personalization / authoring | Assign unassigned voices to pose pads first, then other pads | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleAutoAssignNaturalPose` | `NaturalHandPose`, `Voice`, `GridMapping` | implemented | Toolbar button `Natural` | Strong signal that Pose 0 is not optional in intended workflow |
+
+## Optimization / Analysis
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Run beam analysis | optimization / analysis | Run the biomechanical solver and store result under `beam` | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleRunSolver`, `src/context/ProjectContext.tsx:runSolver` | `solverResults`, `activeSolverId`, `EngineResult` | implemented | Default analysis path | User sees "Run Analysis," not "Run Beam" |
+| Run genetic analysis | optimization / analysis | Run async genetic solver with progress bar | Yes, when advanced | `/workbench` | `src/workbench/Workbench.tsx`, `src/context/ProjectContext.tsx:runSolver` | `solverResults['genetic']` | implemented | Advanced toggle and progress bar | Advanced-only, so somewhat hidden |
+| Solver result switching | optimization / analysis | Choose which stored solver result drives visualized analysis | Yes, when advanced | `/workbench` | `src/workbench/Workbench.tsx`, `src/context/ProjectContext.tsx:setActiveSolverId` | `activeSolverId`, `solverResults` | implemented | Result selector in advanced mode | Comparison meaning depends on mapping consistency |
+| Auto-arrange / annealing layout optimization | optimization / analysis | Optimize current mapping and overwrite it with best mapping | Yes | `/workbench` | `src/workbench/Workbench.tsx:handleOptimizeLayout`, `src/context/ProjectContext.tsx:optimizeLayout` | `GridMapping`, `solverResults['annealing']`, `layoutMode='optimized'` | implemented | Toolbar button `Auto-Arrange` | Optimization is blocked unless mapping coverage is complete |
+| Mapping coverage enforcement before optimization | optimization / analysis | Prevent optimize if performance notes are unmapped | Hidden but user-visible via alert | `/workbench` | `src/workbench/Workbench.tsx`, `src/engine/mappingCoverage.ts` | `MappingCoverageResult` | implemented | Alert names unmapped notes | Important product rule not surfaced before failure |
+| Analysis summary panel | optimization / analysis | Show ergonomic score, event count, hand balance, cost metrics, assignment table | Yes | `/workbench` | `src/workbench/AnalysisPanel.tsx` | `EngineResult.averageMetrics`, `fingerUsageStats` | implemented | Summary tab | Primary "at a glance" analysis surface |
+| Solver comparison panel | optimization / analysis | Compare beam vs genetic cost, balance, fatigue, evolution graph | Yes, when advanced | `/workbench` | `src/workbench/AnalysisPanel.tsx` | `solverResults['beam']`, `solverResults['genetic']` | implemented | Comparison tab gated by `showAdvanced` | Niche but active |
+| Optimization-process panel | optimization / analysis | Visualize annealing progress and acceptance rate | Yes | `/workbench` | `src/workbench/AnalysisPanel.tsx` | `solverResults['annealing'].optimizationLog` | implemented | Optimization tab | Tied to annealing result availability |
+| Finger assignment table | optimization / analysis | Show note-to-finger assignment summary | Yes | `/workbench` | `src/workbench/SoundAssignmentTable.tsx`, `src/workbench/AnalysisPanel.tsx` | `GridMapping`, `EngineResult.debugEvents` | implemented | Summary tab lower section | Another analysis representation of the same solver output |
+
+## Visualization / Inspection
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Grid finger-color overlay | visualization | Color placed pads by inferred or manual finger assignment | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx:fingerAssignmentMap` | `manualAssignments`, `EngineResult.debugEvents` | implemented | Cell background and badges | Depends on analysis already existing |
+| Finger legend | visualization | Show left/right finger color legend | Yes | `/workbench` | `src/workbench/FingerLegend.tsx`, `src/workbench/LayoutDesigner.tsx` | finger color system | implemented | Always visible under grid | Good explanatory affordance |
+| Reachability heatmap | visualization | Visualize reachable pads from a selected anchor for L1/R1 | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx`, `src/engine/feasibility.ts:getReachabilityMap` | `ReachabilityLevel` | implemented | Context menu `Show Reach for L1/R1` | Hidden feature with strong analysis value |
+| Layout mode indicator | visualization | Show current mapping origin/status such as Manual, Random, Optimized | Yes | `/workbench` | `src/workbench/LayoutDesigner.tsx` | `GridMapping.layoutMode`, `version` | implemented | Floating grid chip | Helpful but not enough for full layout identity |
+| Timeline page | visualization | Show performance chronologically across voice lanes with finger labels | Yes | `/timeline` | `src/pages/TimelinePage.tsx`, `src/workbench/Timeline.tsx` | `Performance`, derived `voices`, finger labels | implemented | Full route | Current page is simpler than several docs suggest |
+| Event analysis page | visualization | Deep-dive route with transition list, onion-skin grid, metrics, practice loop | Yes | `/event-analysis` | `src/pages/EventAnalysisPage.tsx`, `src/workbench/EventAnalysisPanel.tsx` | `AnalyzedEvent`, `Transition`, `OnionSkinModel` | implemented | Full route | This is the richest analysis surface |
+| Cost debug page | visualization / debug | Developer-only route for per-event cost breakdown and annealing trace | Dev-only | `/cost-debug` | `src/pages/CostDebugPage.tsx` | `EngineDebugEvent`, `annealingTrace`, `CostBreakdown` | implemented | Dev-gated route and page | Explicitly not part of production UX |
+
+## Event Analysis / Practice
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Event timeline list | analysis / inspection | Scrollable transition list colored by composite difficulty | Yes | `/event-analysis` | `src/workbench/EventTimelinePanel.tsx` | `Transition.metrics.compositeDifficultyScore` | implemented | Left panel timeline tab | Event means grouped moment, not raw note |
+| Event log table | analysis / inspection | Sorted table of debug events with manual hand/finger override controls | Yes | `/event-analysis` | `src/workbench/EventLogTable.tsx` | `EngineDebugEvent`, `manualAssignments` | implemented | Left panel log tab | Sort order uses eventKey fallback logic; still somewhat brittle |
+| Onion-skin grid | analysis / visualization | Shows current, previous, next pads and finger movement context | Yes | `/event-analysis` | `src/components/vis/OnionSkinGrid.tsx`, `src/engine/onionSkinBuilder.ts` | `OnionSkinModel` | implemented | Center panel | Current tests indicate data-shape drift around this model |
+| Transition metrics panel | analysis / inspection | Shows time delta, distance, speed pressure, stretch, and flags | Yes | `/event-analysis` | `src/workbench/TransitionMetricsPanel.tsx` | `TransitionMetrics` | implemented | Right panel | Clear drill-down component |
+| Practice loop | analysis / practice | Visual loop stepping between selected event and next event at chosen speed | Yes | `/event-analysis` | `src/workbench/PracticeLoopControls.tsx`, `src/hooks/usePracticeLoop.ts` | selected event index, timer state | partial | Hook comments explicitly say MVP visual-only stepping | No actual MIDI/audio playback |
+| Export event metrics JSON | analysis / export | Download all event and transition metrics | Yes | `/event-analysis` | `src/workbench/EventAnalysisPanel.tsx`, `src/utils/eventExport.ts` | `AnalyzedEvent[]`, `Transition[]` | implemented | Export button | Output is analysis-specific, separate from project JSON |
+| Export hard transitions JSON | analysis / export | Download transitions above difficulty threshold | Yes | `/event-analysis` | same as above | `Transition[]` | implemented | Export button | Threshold hardcoded at `0.7` in handler |
+| Export practice-loop settings JSON | analysis / export | Download currently selected loop index and available speeds | Yes | `/event-analysis` | same as above | selected index, speed options | implemented | Export button | Mostly a configuration artifact, not a rich practice artifact |
+
+## Persistence / Import / Export
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Per-song autosave | persistence | Persist current project state to song-specific localStorage entry | Mostly implicit | `/workbench` | `src/workbench/Workbench.tsx`, `src/services/SongService.ts:saveSongState` | `ProjectState`, `Song.projectStateId` | implemented | 1-second debounced save | Major product behavior with little explicit UX explanation |
+| Song metadata persistence | persistence | Persist song metadata and MIDI linkage | Yes | `/` | `src/services/SongService.ts` | `Song`, `SongMetadata` | implemented | LocalStorage `push_perf_songs` | Local-first only |
+| Project JSON export | persistence / export | Download full `ProjectState` as JSON | Yes | `/workbench` | `src/workbench/Workbench.tsx`, `src/utils/projectPersistence.ts:saveProject` | `ProjectState` | implemented | Save Project button | Separate from per-song autosave |
+| Project JSON import | persistence / import | Load full `ProjectState` from JSON with strict validation | Yes | `/workbench` | `src/workbench/Workbench.tsx`, `src/utils/projectPersistence.ts:loadProject` | `ProjectState` | implemented | Load button and validation result banner | Current build errors reduce confidence in type correctness |
+| Strict file validation | persistence / import | Reject malformed project files and default some additive fields | Hidden | `/workbench` load flow | `src/utils/projectPersistence.ts:validateProjectStrict` | `ProjectState`, `NaturalHandPose` | implemented | Validation result structure | Good hidden capability |
+| Lenient localStorage hydration | persistence | Sanitize saved state from localStorage | Hidden | all routed song pages | `src/utils/projectPersistence.ts:validateProjectState` | `ProjectState` | implemented | Used by `SongService.loadSongState` | Important difference from file import path |
+
+## Theming / UI Shell
+
+| Feature Name | Category | Description | User-visible? | Primary page/route | Supporting files/components | Related state/domain objects | Status | Evidence | Notes / ambiguities |
+|---|---|---|---|---|---|---|---|---|---|
+| Theme toggle | theming / UI shell | Toggle light/dark theme | Yes | `/workbench` | `src/components/ThemeToggle.tsx`, `src/context/ThemeContext.tsx` | `theme` | implemented | Header theme toggle | Currently only exposed on Workbench |
+| Theme persistence | theming / UI shell | Persist theme in localStorage | Hidden but user-observable | app-wide | `src/context/ThemeContext.tsx` | localStorage key `push_perf_theme` | implemented | Reads and writes from localStorage | Older audit docs claiming non-persistence are stale |
+| Song/workbench navigation shell | theming / UI shell | Provide route links between portfolio, workbench, timeline, event analysis, and dev debug | Yes | multiple routes | `src/main.tsx`, headers in page components | route/query state | implemented | Current routes explicitly defined | Strong navigation redundancy around analysis |
+
+## Hidden, Duplicate, and Planned-Looking Features
+
+### Duplicate features across pages
+
+| Duplicated concept | Surfaces | Evidence | Product concern |
+|---|---|---|---|
+| Performance analysis | Workbench `AnalysisPanel`, `EventAnalysisPage`, `TimelinePage`, `CostDebugPage` | `src/workbench/AnalysisPanel.tsx`, `src/pages/EventAnalysisPage.tsx`, `src/pages/TimelinePage.tsx`, `src/pages/CostDebugPage.tsx` | Hard to tell which is canonical summary vs drill-down vs debug |
+| Finger assignment visualization | Grid heatmap, finger assignment table, timeline labels, event log, onion skin | same | Strong value, but repeated in disconnected representations |
+| Manual edit of assignment meaning | Grid drag, finger locks, event log overrides | `LayoutDesigner`, `EventLogTable` | Multiple kinds of "assignment" are easy to confuse |
+
+### Hidden features that exist in code but are not clearly surfaced
+
+| Feature | Evidence | Why it matters |
+|---|---|---|
+| `SongService.importSongFromMidi` | `src/services/SongService.ts` | Product can support direct import, but current main UX does not expose it |
+| Layout templates | `src/types/layout.ts:STANDARD_KIT_TEMPLATE`, `LAYOUT_TEMPLATES` | Suggests intended template workflow that is not visible |
+| `sectionMaps` data model | `src/types/performance.ts:SectionMap`, `src/types/projectState.ts` | Suggests a song-section workflow that is currently dormant |
+| Reachability visualization | `src/workbench/LayoutDesigner.tsx` context menu | Valuable analysis aid but discoverability is low |
+
+### Features that appear planned but incomplete
+
+| Feature | Evidence | Current reading |
+|---|---|---|
+| Practice as a first-class user workflow | Song cards route only to Editor and Analyze; practice loop is visual-only | The product seems to want practice support, but it is not yet a complete user flow |
+| Rich section-based optimization | Workbench header says "Section Layout Optimizer"; `sectionMaps` remain in state | Product language still implies a broader section model than active UX supports |
+| Template-based assignment | Template types exist, but `templateSlot` is always `null` in `LayoutDesigner` | Planned or abandoned |
+| Alternative instrument layouts | `InstrumentConfig.layoutMode` only supports `'drum_64'`, but docs mention future modes | Planned, not active |
+

--- a/docs/product-synthesis/GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md
+++ b/docs/product-synthesis/GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md
@@ -1,0 +1,256 @@
+# Gaps, Duplications, and Product Confusion
+
+## Tone and Scope
+
+This document is intentionally direct. The goal is to surface where the current product definition is unclear, contradictory, duplicated, or drifting so that future product artifacts can resolve those issues instead of inheriting them.
+
+## Duplicated Concepts
+
+### Analysis exists in too many overlapping forms
+
+| Concept | Where it appears | Why it is a problem |
+|---|---|---|
+| top-level playability summary | Workbench `AnalysisPanel`, Event Analysis header, Cost Debug aggregate metrics | No single canonical "summary analysis" surface |
+| finger assignment visualization | Workbench grid, finger assignment table, Timeline labels, Event Log, OnionSkinGrid | Strong concept, but scattered into many representations |
+| difficult-transition inspection | Timeline implies sequence review, Event Analysis explicitly measures transitions, Cost Debug exposes per-event costs | Overlap without clear screen roles |
+
+### Mapping generation has too many "first step" actions
+
+Current choices after import:
+
+- drag manually
+- `Seed`
+- `Natural`
+- `Random`
+- `Organize by 4x4 Banks`
+- `Auto-Arrange`
+
+Problem:
+
+- The product does not make it clear which of these is the recommended first move for a normal user.
+
+## Duplicated Pages / Workflows
+
+### Workbench vs Event Analysis
+
+- Workbench already contains a rich analysis panel.
+- Event Analysis is also a rich analysis workbench.
+- Result:
+  - "Analyze here or there?" is not clearly answered.
+
+### Timeline vs Event Analysis
+
+- Both are time-oriented inspection surfaces.
+- Timeline is broader and simpler.
+- Event Analysis is deeper and more diagnostic.
+- Result:
+  - The relationship is implicit rather than designed as a clear drill-down hierarchy.
+
+### Workbench vs Cost Debug
+
+- Both can explain solver output.
+- Cost Debug is explicitly developer-facing.
+- Result:
+  - The product boundary between user-facing explanation and internal diagnostics is not documented clearly.
+
+## Inconsistent Terminology
+
+### `layout` is overloaded
+
+It currently refers to at least four things:
+
+1. `LayoutSnapshot` as a container for a `Performance`
+2. `GridMapping` as a voice-to-pad placement
+3. layout mode or layout generation history
+4. the overall idea of an ergonomic arrangement
+
+Evidence:
+
+- `src/types/projectState.ts`
+- `src/types/layout.ts`
+- `src/workbench/Workbench.tsx`
+- header subtitle `Section Layout Optimizer`
+
+### `voice`, `sound`, and `note` are still mixed
+
+- `Voice` is now the clearest canonical code term.
+- Many handlers and components still use `sound`.
+- User-facing descriptions sometimes still imply "note" where the system really means the reusable pitch/voice object.
+
+Evidence:
+
+- `src/types/layout.ts`
+- `src/workbench/Workbench.tsx`
+- `src/workbench/VoiceLibrary.tsx`
+- `docs/TERMINOLOGY.md`
+
+### Hand/finger notation is inconsistent
+
+- internal forms include:
+  - `left/right`
+  - `L/R`
+  - `LH/RH`
+  - `L1-R5`
+- This is manageable technically, but weak for a clean product-language canon.
+
+## Inconsistent Data Models
+
+### `sectionMaps` are present but not product-active
+
+- `ProjectState` includes `sectionMaps`.
+- `SectionMap` is defined.
+- The Workbench header still says `Section Layout Optimizer`.
+- Current live routes do not present a real section workflow.
+
+Implication:
+
+- Either sections remain part of the planned product and need re-expression, or the current product definition should stop implying them.
+
+### Templates exist in types, not in user workflow
+
+- `STANDARD_KIT_TEMPLATE` and `LAYOUT_TEMPLATES` exist in `src/types/layout.ts`.
+- `LayoutDesigner` currently passes `templateSlot={null}`.
+
+Implication:
+
+- A template-driven mapping concept exists in the model but not in the product.
+
+### Song metadata is richer than current portfolio behavior
+
+- `SongMetadata` includes:
+  - favorite state
+  - tags
+  - difficulty
+  - practice time
+  - performance rating
+- Current Dashboard uses only a narrow subset.
+
+Implication:
+
+- The product may be torn between:
+  - "song portfolio / practice library"
+  - "mapping workstation"
+
+## Feature Drift
+
+### Docs and code have drifted
+
+Examples:
+
+- `docs/PROJECT_OVERVIEW.md` still describes a central reactive solver loop and a different build-state picture than current code.
+- `docs/DASHBOARD_USER_FLOW_DOCUMENTATION.md` still describes a direct import button path and a `Practice` button that no longer exists in current `SongCard`.
+- `docs/audit/01_feature_map.md` claims missing `test` and `typecheck` scripts, but current `package.json` includes them.
+
+Implication:
+
+- Repo docs cannot be treated as a single coherent product source.
+- Current source code should remain the primary truth for synthesis.
+
+### Tests and current models have drifted
+
+Examples from 2026-03-13 verification:
+
+- `src/engine/__tests__/eventMetrics.test.ts` expects a different analyzed-event shape than current implementation exposes.
+- `src/engine/__tests__/onionSkinBuilder.test.ts` uses an older event model that does not match the current grouped `AnalyzedEvent` structure.
+- `src/engine/__tests__/core.test.ts` and `src/engine/__tests__/solver.fixtures.test.ts` show solver-behavior expectation drift or regression.
+
+Implication:
+
+- The product's analysis model is still moving.
+- Future UX artifacts should separate "intended user concept" from "current unstable implementation details."
+
+## Unclear Primary Workflow
+
+### The app does not yet strongly teach a recommended path
+
+A likely intended path from current code is:
+
+1. Link MIDI
+2. Open Workbench
+3. Configure Pose 0
+4. Seed or use Natural assignment
+5. Run Analysis
+6. Auto-Arrange if needed
+7. Inspect Timeline / Event Analysis
+
+Problem:
+
+- The UI does not clearly present this sequence.
+- Instead, it exposes many equally weighted controls at once.
+
+### Empty import model is correct but underexplained
+
+- The explicit empty-grid model is consistent in current code.
+- It fixes earlier confusion from auto-layout on import.
+- But the app still lacks a clear first-run teaching layer that explains:
+  - why the grid is empty
+  - what the staging area means
+  - why `Seed` or `Natural` is useful
+
+## Hidden Assumptions
+
+| Hidden assumption | Where it shows up | Why it matters |
+|---|---|---|
+| Pose 0 meaningfully improves the product | seed, natural assignment, solver neutral override | Could be product-defining, but the top-level framing does not say so |
+| Users will understand note coverage before optimization | optimization blocking alert only | This is a critical workflow rule |
+| Users can distinguish a voice from a note event from a pad | current mixed terminology and advanced tooling | Many core interactions depend on this mental model |
+| Local browser storage is an acceptable persistence model | current architecture is fully local-first | Product messaging does not explicitly set this expectation |
+
+## Suspected UX Confusion Points
+
+1. Empty song creation before MIDI linkage.
+2. Multiple authoring helpers with unclear recommended order.
+3. `Run Analysis` vs `Auto-Arrange` vs `Natural` vs `Seed`.
+4. Hidden right-click affordances for important behaviors like finger locks and reachability.
+5. Multiple analysis routes without a clear "use this one when..." explanation.
+6. Practice language that suggests more capability than currently exists.
+
+## Code / Docs Mismatch
+
+| Topic | Current code truth | Conflicting or stale artifact |
+|---|---|---|
+| route set | Dashboard, Workbench, Timeline, Event Analysis, dev-only Cost Debug | some older docs imply different page emphasis |
+| analysis state model | `engineResult` derived from `solverResults[activeSolverId]` | older docs/audits still describe a legacy dual-result model as central |
+| theme persistence | theme now persists in localStorage | older audit notes say theme resets |
+| dashboard practice action | current `SongCard` shows `Editor` and `Analyze` only | older docs mention a `Practice` button |
+| timeline scope | current route is mostly a viewer with zoom and click-to-seek | older docs/audits describe richer practice/playback controls |
+
+## Legacy vs Current Uncertainty
+
+### Likely current
+
+- explicit empty-grid import
+- centralized route hydration via `useSongStateHydration`
+- solver results stored in `ProjectState.solverResults`
+- Pose 0 as a core input to several flows
+
+### Likely legacy or drifting
+
+- reactive analysis as the primary visible result path
+- richer section-based workflow
+- template-driven or ghost-template workflow
+- stronger practice-mode workflow
+
+## Build / Test Health as Product Signal
+
+This is not only an engineering issue; it affects synthesis confidence.
+
+- `npm run build` failing means the current working product definition is not fully stabilized in code.
+- `npm run test:run` failing means some previously intended behaviors are no longer aligned with the current implementation.
+
+This suggests the product is still in a design-convergence stage rather than a mature stabilization stage.
+
+## Questions That Need Human Product Judgment
+
+1. Is the product primarily for:
+   - personalized performance layout design
+   - solver/ergonomics analysis
+   - song/practice management
+   - some combination, with a declared primary
+2. Is Pose 0 mandatory setup, guided setup, or optional advanced setup?
+3. Which of `Seed`, `Natural`, `Random`, and `Auto-Arrange` should be first-class in the UI?
+4. Should Event Analysis remain a separate full page, or become the canonical analysis surface with Workbench reduced to summary?
+5. Do sections still matter to the product, or should section language and models be deprecated?
+6. Is the product local-first by design, or only temporarily local-first?
+7. What artifact should define the core user mission before any UX redesign proceeds?
+

--- a/docs/product-synthesis/PRODUCT_OVERVIEW_FIRST_DRAFT.md
+++ b/docs/product-synthesis/PRODUCT_OVERVIEW_FIRST_DRAFT.md
@@ -1,0 +1,219 @@
+# Product Overview First Draft
+
+## Scope and Method
+
+This document is a first-draft product synthesis derived from current repository evidence on 2026-03-13. It prioritizes current code behavior over older documentation when they conflict.
+
+- Primary evidence reviewed from code:
+  - `src/main.tsx`
+  - `src/pages/Dashboard.tsx`
+  - `src/workbench/Workbench.tsx`
+  - `src/workbench/LayoutDesigner.tsx`
+  - `src/workbench/AnalysisPanel.tsx`
+  - `src/workbench/EventAnalysisPanel.tsx`
+  - `src/pages/TimelinePage.tsx`
+  - `src/pages/EventAnalysisPage.tsx`
+  - `src/context/ProjectContext.tsx`
+  - `src/services/SongService.ts`
+  - `src/utils/midiImport.ts`
+  - `src/types/*`
+  - `src/engine/*`
+- Supporting repo-document evidence:
+  - `README.md`
+  - `docs/PROJECT_OVERVIEW.md`
+  - `docs/WORKBENCH_DOCUMENTATION.md`
+  - `docs/DASHBOARD_USER_FLOW_DOCUMENTATION.md`
+  - `docs/TERMINOLOGY.md`
+  - `docs/MilestoneNotes/2025-11-29-explicit-layout-model.md`
+  - `docs/ROADMAP_AND_FUTURE_WORK.md`
+- Reliability signal:
+  - `npm run test:run` failed on 2026-03-13 with 24 failing tests.
+  - `npm run build` failed on 2026-03-13 due to current TypeScript errors.
+
+## One-Paragraph Product Summary
+
+The product currently appears to be a local-first browser tool for analyzing the physical playability of MIDI performances on an Ableton Push-style 8x8 pad grid, then helping a user author, seed, inspect, and optimize note-to-pad mappings for that performance. The practical center of the product is the Workbench (`src/workbench/Workbench.tsx`), where a song's MIDI-derived voices can be placed on the grid manually or by algorithm, evaluated by a biomechanical solver, and inspected through summary metrics, timeline views, and event-level transition analysis.
+
+## Likely Primary User(s)
+
+### Most likely primary user
+
+- A technically inclined musician, producer, or finger-drumming performer working with Ableton Push or Push-like pad layouts.
+- Evidence:
+  - `README.md` describes analyzing MIDI for Ableton Push and generating musician-adaptive pad layouts.
+  - `src/types/performance.ts` and `src/engine/gridMapService.ts` assume an 8x8 `drum_64` Push mapping model.
+  - `src/workbench/NaturalHandPosePanel.tsx` assumes a user can define a personal resting hand pose.
+
+### Likely secondary users
+
+- A developer or power user validating solver behavior and cost breakdowns.
+- Evidence:
+  - Dev-only `src/pages/CostDebugPage.tsx`.
+  - Extensive `debugEvents`, `annealingTrace`, and cost-breakdown models in engine code.
+
+## Likely Core Job To Be Done
+
+When a performer has a MIDI-derived performance they want to play on Push, they want to map the required notes onto pads in a way that fits their body, hand posture, and movement limits so they can produce a playable, lower-friction performance layout.
+
+Evidence:
+
+- `src/utils/midiImport.ts` converts MIDI into `Performance`, `Voice[]`, `InstrumentConfig`, and an initially empty `GridMapping`.
+- `src/workbench/Workbench.tsx` exposes layout controls named `Seed`, `Natural`, `Auto-Arrange`, `Random`, and `Run Analysis`.
+- `src/context/ProjectContext.tsx` runs solvers and layout optimization against the active performance and mapping.
+
+## Major Workflows the App Appears To Support
+
+1. Manage a local song portfolio and attach MIDI to songs.
+   - `src/pages/Dashboard.tsx`
+   - `src/components/dashboard/SongCard.tsx`
+   - `src/services/SongService.ts`
+
+2. Hydrate a song-specific project state and open the Workbench.
+   - `src/hooks/useSongStateHydration.ts`
+   - `src/workbench/Workbench.tsx`
+
+3. Define a personal natural hand pose ("Pose 0").
+   - `src/workbench/NaturalHandPosePanel.tsx`
+   - `src/types/naturalHandPose.ts`
+
+4. Assign voices to pads manually or through deterministic/random layout helpers.
+   - `src/workbench/LayoutDesigner.tsx`
+   - `src/workbench/VoiceLibrary.tsx`
+   - `src/workbench/Workbench.tsx:handleSeedFromPose0`
+   - `src/workbench/Workbench.tsx:handleAutoAssignNaturalPose`
+   - `src/workbench/Workbench.tsx:handleAutoAssignRandom`
+
+5. Run performance analysis and inspect summary metrics.
+   - `src/context/ProjectContext.tsx:runSolver`
+   - `src/workbench/AnalysisPanel.tsx`
+
+6. Optimize the layout using simulated annealing.
+   - `src/context/ProjectContext.tsx:optimizeLayout`
+   - `src/workbench/Workbench.tsx:handleOptimizeLayout`
+
+7. Inspect the result through alternate analysis surfaces.
+   - Timeline view: `src/pages/TimelinePage.tsx`
+   - Event analysis: `src/pages/EventAnalysisPage.tsx`, `src/workbench/EventAnalysisPanel.tsx`
+   - Cost debug: `src/pages/CostDebugPage.tsx`
+
+8. Persist, export, and reload state.
+   - Autosave via `src/workbench/Workbench.tsx` + `src/services/SongService.ts`
+   - Project JSON via `src/utils/projectPersistence.ts`
+   - Event-analysis JSON exports via `src/utils/eventExport.ts`
+
+## Major Subsystems / Modules
+
+| Subsystem | What it does now | Primary evidence |
+|---|---|---|
+| Song portfolio | Local song CRUD, MIDI linking, launch points into editing/analysis | `src/pages/Dashboard.tsx`, `src/components/dashboard/SongCard.tsx`, `src/services/SongService.ts` |
+| Workbench shell | Main editing and orchestration surface | `src/workbench/Workbench.tsx` |
+| Grid layout editor | Drag/drop placement, finger locks, reachability, visibility controls | `src/workbench/LayoutDesigner.tsx`, `src/workbench/VoiceLibrary.tsx` |
+| Natural hand pose system | User-defined finger resting pads used by seeding and solver neutral state | `src/workbench/NaturalHandPosePanel.tsx`, `src/types/naturalHandPose.ts`, `src/engine/handPose.ts` |
+| Solver / engine | Biomechanical assignment, scoring, optimization, debug output | `src/engine/core.ts`, `src/engine/costFunction.ts`, `src/engine/feasibility.ts`, `src/engine/solvers/*` |
+| Event-analysis pipeline | Groups events into moments, computes transitions, builds onion-skin models, exports analysis data | `src/engine/eventMetrics.ts`, `src/engine/transitionAnalyzer.ts`, `src/engine/onionSkinBuilder.ts`, `src/workbench/EventAnalysisPanel.tsx` |
+| Timeline visualization | Chronological lane view of mapped voices and finger labels | `src/workbench/Timeline.tsx`, `src/pages/TimelinePage.tsx` |
+| Persistence | LocalStorage songs and project state, JSON import/export | `src/services/SongService.ts`, `src/utils/projectPersistence.ts` |
+| Theme / shell | Theme persistence and app-level shell | `src/context/ThemeContext.tsx`, `src/styles/theme.css` |
+| Diagnostics | Per-event cost debug and annealing trace review | `src/pages/CostDebugPage.tsx` |
+
+## Current State of the Product
+
+Best first-pass characterization:
+
+- Directionally coherent
+  - The repo consistently centers on "Push playability" and "layout ergonomics."
+- Operational but fragmented
+  - The same product concept is expressed across multiple pages and panels with overlapping analysis models.
+- Partially duplicated
+  - Analysis exists in the Workbench summary, Event Analysis page, Timeline page, and Cost Debug page.
+- Partially experimental
+  - Tests and docs show active model churn, especially around event-analysis shapes and solver behavior.
+- Partially under-converged
+  - The product model has improved around `Voice`, `GridMapping`, and `NaturalHandPose`, but terminology and workflow framing are still not fully unified.
+
+## Key Product Tensions or Contradictions
+
+1. Is the core product a layout editor with analysis, or an analysis tool with editing?
+   - The Workbench is the practical hub, but route names and docs also position deep analysis as a primary surface.
+
+2. What is the intended first successful path after MIDI import?
+   - Current code makes the grid intentionally empty after import (`src/utils/midiImport.ts`, `docs/MilestoneNotes/2025-11-29-explicit-layout-model.md`).
+   - The user can then drag manually, use `Natural`, use `Seed`, use `Random`, or use `Auto-Arrange`.
+   - This is powerful, but it leaves the canonical "start here" flow unclear.
+
+3. Is `NaturalHandPose` a supporting preference or the conceptual core?
+   - In code it is central to seeding, deterministic assignment, and solver neutral bias.
+   - In top-level product framing it is still underemphasized.
+
+4. Is the product centered on songs, performances, layouts, mappings, or sections?
+   - The dashboard is song-centric.
+   - The engine is performance-centric.
+   - The Workbench edits mappings.
+   - Header copy still says "Section Layout Optimizer" even though `sectionMaps` are mostly dormant.
+
+5. Is analysis live, snapshot-based, or both?
+   - Current code mostly exposes solver snapshots through `solverResults` and `activeSolverId`.
+   - Older docs and audits still describe a live reactive solver loop as central.
+   - The product language has not caught up to that shift.
+
+## Where the Product Vision Appears Clear
+
+- The app is about Push-style pad performance ergonomics, not generic music production.
+- MIDI import produces a performance to be mapped, not a finished layout to accept as-is.
+- Layout quality is judged by biomechanical cost and finger assignment, not only musical convention.
+- The user should be able to personalize the system with a hand-pose model.
+- The system wants to support both authoring and analysis, not only one or the other.
+
+## Where the Product Vision Appears Blurry
+
+- The canonical primary workflow and recommended sequence after import.
+- Whether songs are simply containers or meaningful portfolio objects with practice-progress semantics.
+- Whether section-based workflow still matters. `sectionMaps` remain in the data model but not in live product behavior.
+- The intended relationship between "analysis", "solver run", and "optimization."
+- The intended scope of timeline/practice functionality. Current practice loop is visual stepping only (`src/hooks/usePracticeLoop.ts`), while some older docs imply richer playback behavior.
+- The intended importance of layout templates. Template models exist in `src/types/layout.ts` but are not surfaced in the main flow.
+
+## Repository Reliability Notes
+
+These do not define the product by themselves, but they materially affect confidence in the extracted behavior.
+
+- `npm run build` currently fails.
+  - Notable current issues include `src/utils/projectPersistence.ts` typing mismatches and a few unused variables.
+- `npm run test:run` currently fails.
+  - Failing clusters show drift between event-analysis tests and current event-analysis data structures:
+    - `src/engine/__tests__/eventMetrics.test.ts`
+    - `src/engine/__tests__/onionSkinBuilder.test.ts`
+  - There are also solver behavior regressions or changed expectations:
+    - `src/engine/__tests__/core.test.ts`
+    - `src/engine/__tests__/solver.fixtures.test.ts`
+- Some repo docs and audit files are stale relative to current code.
+  - Example: current `src/context/ProjectContext.tsx` derives `engineResult` from `solverResults`, while older docs describe a still-active legacy engine-result path as central.
+
+## Highest-Value Human Decisions Needed
+
+1. Define the primary workflow after MIDI import.
+   - Should the product explicitly guide the user toward `Pose -> Seed -> Auto-Arrange -> Analyze`, or something else?
+
+2. Decide what the product's main object is.
+   - Song portfolio?
+   - Performance-to-layout editor?
+   - Personalized ergonomics optimizer?
+
+3. Decide whether `NaturalHandPose` is optional personalization or required setup.
+   - The code increasingly treats it as foundational.
+
+4. Clarify the role of multiple analysis surfaces.
+   - Which view is the canonical analysis summary?
+   - Which views are detail drill-downs?
+   - Which should remain developer-only?
+
+5. Decide whether section-based modeling is still part of the product.
+   - If yes, it needs workflow/UI expression.
+   - If no, product language and dormant model fields should stop implying it.
+
+6. Define whether the product is a local portfolio tool, an exportable workstation, or both.
+   - The current app mixes per-song autosave, project JSON export, and analysis-export JSON without a single user-facing persistence story.
+
+7. Canonicalize terminology for the user-facing product.
+   - Especially `song`, `performance`, `layout`, `mapping`, `voice`, `pad`, `note`, and `analysis`.
+

--- a/docs/product-synthesis/RECOMMENDED_NEXT_ARTIFACTS.md
+++ b/docs/product-synthesis/RECOMMENDED_NEXT_ARTIFACTS.md
@@ -1,0 +1,148 @@
+# Recommended Next Artifacts
+
+## Guidance
+
+These are recommended next artifacts for a human + LLM collaboration. They are ordered to close the highest-value product-definition gaps before any visual redesign or implementation planning.
+
+## Recommended Creation Order
+
+| Order | Artifact name | Purpose | Why it is needed now | Feeds from these synthesis docs |
+|---|---|---|---|---|
+| 1 | User Mission | State the product's single primary mission in one durable statement | The repo currently mixes song portfolio, mapping workstation, and analysis-tool identities | `PRODUCT_OVERVIEW_FIRST_DRAFT.md`, `USER_GOALS_AND_JOBS_TO_BE_DONE.md`, `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md` |
+| 2 | Core User Goals | Freeze the ranked set of primary and secondary user goals | Current goal hierarchy is implied, not declared | `USER_GOALS_AND_JOBS_TO_BE_DONE.md`, `PRODUCT_OVERVIEW_FIRST_DRAFT.md` |
+| 3 | JTBD Canon | Finalize 1-3 primary jobs to be done and optional secondary jobs | Prevents future UX work from optimizing for mixed or conflicting jobs | `USER_GOALS_AND_JOBS_TO_BE_DONE.md`, `ARTIFACT_INPUTS_CHECKLIST.md` |
+| 4 | Canonical Terminology Doc | Declare the user-facing vocabulary and retire overloaded terms | The current repo still suffers from `layout` / `mapping` / `voice` / `sound` drift | `DOMAIN_MODEL_AND_TERMINOLOGY.md`, `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md` |
+| 5 | Domain Source-of-Truth Spec | Freeze the core product objects and their relationships | Needed before detailed UX specs or acceptance criteria | `DOMAIN_MODEL_AND_TERMINOLOGY.md`, `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md` |
+| 6 | Workflow Maps | Turn current inferred workflows into approved canonical user flows | Current product exposes many valid but competing paths | `WORKFLOW_AND_TASK_INVENTORY.md`, `SCREEN_ROUTE_AND_PANEL_MAP.md` |
+| 7 | Screen Architecture Spec | Define which screens are primary, secondary, drill-down, or internal | Needed to resolve Workbench vs Timeline vs Event Analysis overlap | `SCREEN_ROUTE_AND_PANEL_MAP.md`, `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md` |
+| 8 | Task-Based UX Spec | Specify tasks, prerequisites, user decisions, success criteria, and system responsibilities | Best bridge from product definition into future interaction design | `WORKFLOW_AND_TASK_INVENTORY.md`, `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md`, `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md` |
+| 9 | Wireframe Brief | Provide a design brief for future wireframes/mockups without prematurely redesigning | The repo is ready for a deliberate brief, not random UI changes | `SCREEN_ROUTE_AND_PANEL_MAP.md`, `VISUALIZATION_AND_FEEDBACK_MODEL.md`, `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md` |
+| 10 | Human QA / Acceptance Checklist | Convert product intent into verifiable, user-facing acceptance checks | Current build/test state is not a sufficient product QA definition | `ARTIFACT_INPUTS_CHECKLIST.md`, `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md`, `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md` |
+
+## Artifact Details
+
+### 1. User Mission
+
+- Purpose
+  - Define the product in one sentence that will constrain all later decisions.
+- Why needed
+  - The current repo mixes at least three possible identities.
+- Inputs
+  - `PRODUCT_OVERVIEW_FIRST_DRAFT.md`
+  - `USER_GOALS_AND_JOBS_TO_BE_DONE.md`
+  - `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md`
+
+### 2. Core User Goals
+
+- Purpose
+  - Rank what the product must help users accomplish.
+- Why needed
+  - The current system exposes more goals than it explicitly prioritizes.
+- Inputs
+  - `USER_GOALS_AND_JOBS_TO_BE_DONE.md`
+  - `PRODUCT_OVERVIEW_FIRST_DRAFT.md`
+
+### 3. JTBD Canon
+
+- Purpose
+  - Turn observed needs into a small set of durable job statements.
+- Why needed
+  - Prevents feature sprawl and keeps future UX focused on real outcomes.
+- Inputs
+  - `USER_GOALS_AND_JOBS_TO_BE_DONE.md`
+
+### 4. Canonical Terminology Doc
+
+- Purpose
+  - Approve final vocabulary for user-facing product and internal specs.
+- Why needed
+  - Current terminology drift is one of the biggest causes of product ambiguity.
+- Inputs
+  - `DOMAIN_MODEL_AND_TERMINOLOGY.md`
+  - `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md`
+
+### 5. Domain Source-of-Truth Spec
+
+- Purpose
+  - Freeze the key objects, ownership, and relationships the UX should respect.
+- Why needed
+  - Future flows and specs depend on clarity about what is actually being edited or analyzed.
+- Inputs
+  - `DOMAIN_MODEL_AND_TERMINOLOGY.md`
+  - `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md`
+  - `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md`
+
+### 6. Workflow Maps
+
+- Purpose
+  - Produce explicit canonical flows with entry conditions, branch rules, and success conditions.
+- Why needed
+  - The current product exposes multiple competing "next actions."
+- Inputs
+  - `WORKFLOW_AND_TASK_INVENTORY.md`
+  - `USER_GOALS_AND_JOBS_TO_BE_DONE.md`
+
+### 7. Screen Architecture Spec
+
+- Purpose
+  - Define the role of each route and major panel in the final product architecture.
+- Why needed
+  - There is strong overlap between Workbench, Timeline, and Event Analysis.
+- Inputs
+  - `SCREEN_ROUTE_AND_PANEL_MAP.md`
+  - `WORKFLOW_AND_TASK_INVENTORY.md`
+  - `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md`
+
+### 8. Task-Based UX Spec
+
+- Purpose
+  - Translate approved workflows into concrete tasks, state transitions, and UI responsibilities.
+- Why needed
+  - This is the most useful pre-wireframe artifact.
+- Inputs
+  - `WORKFLOW_AND_TASK_INVENTORY.md`
+  - `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md`
+  - `VISUALIZATION_AND_FEEDBACK_MODEL.md`
+  - `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md`
+
+### 9. Wireframe Brief
+
+- Purpose
+  - Give future wireframe or mockup work a sharp brief that reflects approved product intent.
+- Why needed
+  - The repo is not ready for design improvisation; it needs structured direction first.
+- Inputs
+  - `SCREEN_ROUTE_AND_PANEL_MAP.md`
+  - `VISUALIZATION_AND_FEEDBACK_MODEL.md`
+  - `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md`
+
+### 10. Human QA / Acceptance Checklist
+
+- Purpose
+  - Define how humans will validate whether the product matches the intended mission, workflows, and terminology.
+- Why needed
+  - Current automated verification is valuable but not sufficient as product acceptance.
+- Inputs
+  - `ARTIFACT_INPUTS_CHECKLIST.md`
+  - `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md`
+  - `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md`
+
+## Suggested Working Sequence
+
+1. Approve a User Mission.
+2. Lock Core User Goals and JTBD.
+3. Lock Terminology and Domain Source of Truth.
+4. Approve canonical Workflow Maps.
+5. Approve Screen Architecture.
+6. Produce Task-Based UX Spec.
+7. Write Wireframe Brief.
+8. Write Human QA / Acceptance Checklist.
+
+## What Not To Do Yet
+
+- Do not jump directly to mockups.
+- Do not start refactoring routes or state models based only on implementation convenience.
+- Do not treat current screen structure as final just because it exists.
+
+The repo now contains enough evidence to author these artifacts well, but it still needs human judgment to resolve mission, hierarchy, and naming before UX architecture should be finalized.
+

--- a/docs/product-synthesis/SCREEN_ROUTE_AND_PANEL_MAP.md
+++ b/docs/product-synthesis/SCREEN_ROUTE_AND_PANEL_MAP.md
@@ -1,0 +1,368 @@
+# Screen, Route, and Panel Map
+
+## Route Inventory
+
+Current routed surfaces are defined in `src/main.tsx`.
+
+| Route | Component | Current purpose | Availability |
+|---|---|---|---|
+| `/` | `Dashboard` | Song portfolio, song creation, MIDI linking, launch point into editing/analysis | always |
+| `/workbench` | `Workbench` | Main layout-editing and analysis workbench | always |
+| `/timeline` | `TimelinePage` | Chronological view of the mapped performance | always |
+| `/event-analysis` | `EventAnalysisPage` | Event-by-event and transition analysis drill-down | always |
+| `/cost-debug` | `CostDebugPage` | Diagnostic view for cost breakdown and annealing trace | development only |
+
+## Likely Navigation Hierarchy
+
+```text
+Dashboard (/)
+  -> Workbench (/workbench?songId=...)
+    -> Timeline View (/timeline?songId=...)
+    -> Event Analysis (/event-analysis?songId=...)
+    -> Cost Debug (/cost-debug?songId=...) [dev only]
+
+Event Analysis
+  -> Back to Workbench
+  -> Dashboard
+
+Timeline
+  -> Back to Workbench
+  -> Dashboard
+
+Cost Debug
+  -> Workbench
+  -> Timeline
+  -> Event Analysis
+  -> Dashboard
+```
+
+## Route-by-Route Map
+
+### `/` - Dashboard
+
+- Purpose
+  - Manage the song portfolio and attach MIDI to song records.
+- Key panels / regions
+  - Header:
+    - Product title `Performability Engine - Song Portfolio`
+    - decorative profile/settings icons
+  - Main grid:
+    - `SongCard` list
+    - `Add New Song` card
+  - Footer:
+    - currently visually present but functionally empty
+- Inputs / actions
+  - Create new empty song
+  - Delete song
+  - Link or re-link MIDI
+  - Edit title and BPM inline
+  - Open Workbench
+  - Open Event Analysis
+- Outputs / visualizations
+  - Song cards with status badges
+  - MIDI-linked indicator
+  - Basic song metadata summary
+- Related workflows
+  - Song creation
+  - MIDI linkage
+  - Route entry into Workbench and Event Analysis
+- Concerns
+  - Empty-song flow creates a shell without teaching the next step.
+  - Footer suggests room for actions, but is currently empty.
+  - The portfolio data model is richer than the current UI.
+- Primary evidence
+  - `src/pages/Dashboard.tsx`
+  - `src/components/dashboard/SongCard.tsx`
+
+### `/workbench` - Workbench
+
+- Purpose
+  - The central editing and orchestration surface for mapping voices to pads, analyzing playability, and optimizing layouts.
+- Major panels / regions
+  - Top application header:
+    - product title
+    - current song indicator
+    - links to Dashboard, Timeline View, Event Analysis, Cost Debug
+    - settings menu
+    - theme toggle
+    - undo/redo
+    - save/load project controls
+  - Mid-level toolbar:
+    - `Clear Grid`
+    - `Seed`
+    - `Natural`
+    - `Auto-Arrange`
+    - `Random`
+    - `Run Analysis`
+    - advanced solver controls when enabled
+  - Main content left/center:
+    - embedded `LayoutDesigner`
+  - Main content right:
+    - `AnalysisPanel`
+- Inputs / actions
+  - all core editing and analysis actions
+  - route navigation to analysis drill-downs
+- Outputs / visualizations
+  - grid editor
+  - voice library
+  - pose editor
+  - analysis summary/comparison/optimization views
+- Related workflows
+  - state hydration
+  - mapping authoring
+  - pose setup
+  - solver execution
+  - optimization
+  - autosave/export
+- Concerns
+  - Very dense header and toolbar with mixed action priority.
+  - Product language still says `Section Layout Optimizer` in the header subtitle, while current live flow is song/mapping centric.
+- Primary evidence
+  - `src/workbench/Workbench.tsx`
+
+### Workbench Embedded Panel Map
+
+#### Left embedded panel in Workbench: `LayoutDesigner` left column
+
+- Purpose
+  - Support authoring inputs that feed the current mapping.
+- Top-level tabs
+  - `Library`
+  - `Pose`
+- `Library` tab major subregions
+  - header `Voice Library`
+  - tabs:
+    - `Detected`
+    - `Unassigned`
+    - `Placed`
+- `Pose` tab major subregions
+  - pose summary or edit panel
+  - finger palettes
+  - preview offset slider
+  - save/clear pose actions
+- Concerns
+  - This panel is one of the strongest workflow hubs in the app.
+  - It mixes harmless editing with destructive operations like event deletion.
+- Primary evidence
+  - `src/workbench/LayoutDesigner.tsx`
+  - `src/workbench/VoiceLibrary.tsx`
+  - `src/workbench/NaturalHandPosePanel.tsx`
+
+#### Center embedded panel in Workbench: grid region
+
+- Purpose
+  - Directly edit and inspect the active mapping.
+- Major subregions
+  - floating layout mode indicator
+  - 8x8 pad grid
+  - finger legend below grid
+  - context menu for pad actions
+- Key controls/components
+  - DnD-enabled pads
+  - inline cell renaming
+  - context actions:
+    - show reach for L1
+    - show reach for R1
+    - assign finger locks
+    - clear finger lock
+    - remove sound
+  - ghost pose markers during pose editing
+- Outputs / visualizations
+  - finger assignment color overlay
+  - finger badge
+  - note labels
+  - position labels
+  - pose markers
+  - finger lock marker
+- Concerns
+  - Highly expressive, but some key interactions are hidden behind right-click.
+- Primary evidence
+  - `src/workbench/LayoutDesigner.tsx`
+
+#### Right embedded panel in Workbench: `AnalysisPanel`
+
+- Purpose
+  - Provide summary and comparison views for the current analysis result.
+- Tabs
+  - `Performance Summary`
+  - `Model Comparison` when advanced mode is on
+  - `Optimization Process`
+- Key contents
+  - ergonomic score
+  - total events
+  - hand balance bar
+  - cost-metric breakdown
+  - finger assignments table
+  - solver comparison table
+  - evolution graph
+  - annealing process graph and stats
+- Concerns
+  - Strong surface, but conceptually overlaps with Event Analysis.
+- Primary evidence
+  - `src/workbench/AnalysisPanel.tsx`
+
+### `/timeline` - Timeline View
+
+- Purpose
+  - Show the mapped performance as a chronological strip of voices and events.
+- Major panels / regions
+  - Header:
+    - back to Workbench
+    - title
+    - song chip
+    - zoom slider
+  - Main body:
+    - `Timeline` component
+- Inputs / actions
+  - adjust zoom
+  - click timeline to seek
+- Outputs / visualizations
+  - voice lanes
+  - event blocks
+  - optional finger labels over notes
+  - current time indicator
+- Related workflows
+  - time-based inspection after mapping/analysis
+- Concerns
+  - Current screen is much narrower in scope than some repo docs imply.
+  - It is a viewer, not a full practice or playback system.
+- Primary evidence
+  - `src/pages/TimelinePage.tsx`
+  - `src/workbench/Timeline.tsx`
+
+### `/event-analysis` - Event Analysis
+
+- Purpose
+  - Deep-dive into grouped events, transitions, and localized difficulty.
+- Major panels / regions
+  - Header:
+    - back link
+    - page title
+    - performance name
+    - score / hard / unplayable summary
+    - links to Dashboard and Workbench
+  - Export bar:
+    - `Export Metrics`
+    - `Export Hard Transitions`
+    - `Export Loop Settings`
+  - Main three-column layout:
+    - left column:
+      - `Timeline` tab
+      - `Event Log` tab
+    - center column:
+      - `OnionSkinGrid`
+    - right column:
+      - `PracticeLoopControls`
+      - `TransitionMetricsPanel`
+- Inputs / actions
+  - select transitions
+  - keyboard up/down
+  - toggle left-panel tab
+  - modify manual hand/finger assignment from event log
+  - start/stop practice loop stepping
+  - export JSON
+- Outputs / visualizations
+  - transition heatmap list
+  - per-note event log
+  - onion-skin grid
+  - transition metrics
+  - event difficulty header summary
+- Related workflows
+  - transition investigation
+  - manual override
+  - analysis export
+- Concerns
+  - This page is the clearest "deep analysis" surface, but it partly duplicates Workbench analysis.
+  - Practice is only visual stepping, not audio or MIDI playback.
+- Primary evidence
+  - `src/pages/EventAnalysisPage.tsx`
+  - `src/workbench/EventAnalysisPanel.tsx`
+
+### `/cost-debug` - Cost Debug
+
+- Purpose
+  - Developer-only inspection of cost breakdown and annealing trace data.
+- Major panels / regions
+  - Header with route links
+  - mode selectors and sort controls
+  - event list or annealing views
+  - detail pane for selected event / metric
+- Inputs / actions
+  - choose sort mode
+  - choose debug mode
+  - select an event
+- Outputs / visualizations
+  - per-event cost breakdown
+  - aggregate average cost breakdown
+  - annealing trace or annealing metrics
+- Related workflows
+  - developer verification
+  - debugging unexpected solver behavior
+- Concerns
+  - Valuable for internal validation, but not a normal end-user workflow.
+- Primary evidence
+  - `src/pages/CostDebugPage.tsx`
+
+## Concept Redundancy Across Screens
+
+| Concept | Where it appears | Notes |
+|---|---|---|
+| Current song context | Dashboard, Workbench header, Timeline header, Event Analysis header, Cost Debug header | Good continuity, but each screen expresses it slightly differently |
+| Analysis summary | Workbench analysis panel, Event Analysis header, Cost Debug aggregate view | Different levels of detail but overlapping conceptual ownership |
+| Finger assignment | Workbench grid overlay, Workbench assignments table, Timeline labels, Event log, Onion-skin vectors | Important concept, but repeated many times |
+| Mapping identity | Workbench layout mode chip, settings duplicate layout, active mapping state | There is no strong page-level mapping identity artifact such as a mapping name/version chip in all routes |
+
+## Page-Level Redundancies
+
+1. Workbench and Event Analysis both behave like "analysis home" pages.
+2. Timeline and Event Analysis are separate drill-downs, but both inspect time-ordered result behavior.
+3. Cost Debug and Event Analysis both expose low-level consequence data for solver decisions, but with different audiences.
+
+## Pages / Surfaces That Seem Overloaded
+
+### Workbench
+
+- Combines:
+  - portfolio-level navigation
+  - editing
+  - pose personalization
+  - optimization
+  - solver comparison
+  - persistence
+  - route hub behavior
+- This makes it powerful, but also the most cognitively dense screen.
+
+### Event Analysis
+
+- It is coherent internally, but it also absorbs:
+  - event log editing
+  - practice stepping
+  - export tools
+  - transition browsing
+  - onion-skin visualization
+- It is more of a "sub-workbench" than a narrow drill-down.
+
+## Pages / Surfaces That Seem Underdefined
+
+### Timeline
+
+- The route exists and works, but it currently exposes a narrower value proposition than the rest of the product.
+- It looks like a viewer, not a full practice mode.
+
+### Dashboard
+
+- The data model implies a stronger portfolio/practice-management role than the current UI fulfills.
+
+## Workflow Hubs
+
+The main workflow hubs in the current product are:
+
+1. `src/pages/Dashboard.tsx`
+   - entry and song selection hub
+2. `src/workbench/Workbench.tsx`
+   - main authoring and orchestration hub
+3. `src/workbench/LayoutDesigner.tsx`
+   - hands-on task execution hub
+4. `src/workbench/EventAnalysisPanel.tsx`
+   - deep inspection hub
+

--- a/docs/product-synthesis/STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md
+++ b/docs/product-synthesis/STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md
@@ -1,0 +1,322 @@
+# State Systems and Source of Truth
+
+## Executive Summary
+
+The app is closest to a single-source-of-truth model when viewed through `ProjectContext.projectState`, but several important product behaviors depend on layered state:
+
+- global domain state in `ProjectState`
+- route hydration logic
+- derived filtered performance
+- persisted per-song localStorage state
+- per-page view state
+- engine-computed solver outputs
+
+The current architecture is much closer to a coherent product-facing state model than some older repo docs suggest, but there are still a few ownership ambiguities.
+
+## State Container Inventory
+
+| State system | What it owns | Source of truth? | Persistence | Primary evidence |
+|---|---|---|---|---|
+| `ProjectContext.projectState` | main project domain state | yes, primary | song-local localStorage plus optional JSON import/export | `src/context/ProjectContext.tsx` |
+| `useProjectHistory` | undo/redo wrapper around `ProjectState` | yes for in-session mutation history | in-memory only | `src/hooks/useProjectHistory.ts` |
+| `ProjectContext.engineResult` | currently selected result to visualize | derived source, not canonical itself | indirectly via `solverResults` in `ProjectState` | `src/context/ProjectContext.tsx` |
+| `ProjectState.solverResults` | stored per-solver analysis outputs | yes for analysis-result persistence | saved with project state | `src/types/projectState.ts`, `src/context/ProjectContext.tsx` |
+| `SongService` localStorage map | song catalog and metadata | yes for portfolio layer | localStorage | `src/services/SongService.ts` |
+| `push_perf_project_<id>` localStorage entries | persisted project states by song | yes for per-song persisted work | localStorage | `src/services/SongService.ts`, `src/utils/projectPersistence.ts` |
+| `ThemeContext` | current theme | yes for theme | localStorage | `src/context/ThemeContext.tsx` |
+| Per-page local UI state | zoom, selected event, menu toggles, progress, edit mode | no, transient | no | page and component files |
+
+## Primary Product Source of Truth: `ProjectState`
+
+### What it contains
+
+`ProjectState` is the main product-facing state object. It currently aggregates:
+
+- imported musical material:
+  - `layouts`
+  - `instrumentConfigs`
+  - `instrumentConfig`
+- editable layout material:
+  - `mappings`
+  - `activeLayoutId`
+  - `activeMappingId`
+  - `parkedSounds`
+- filtering and overrides:
+  - `ignoredNoteNumbers`
+  - `manualAssignments`
+- solver configuration and outputs:
+  - `engineConfiguration`
+  - `solverResults`
+  - `activeSolverId`
+- personalization:
+  - `naturalHandPoses`
+- legacy or dormant structure:
+  - `sectionMaps`
+
+Primary evidence:
+
+- `src/types/projectState.ts`
+- `src/context/ProjectContext.tsx`
+
+### Why it is the effective source of truth
+
+- Workbench edits write into it.
+- Route hydration loads it.
+- Timeline and Event Analysis read from it.
+- Project export/import serializes it.
+- Solver outputs are stored back into it.
+
+## Secondary Durable Source of Truth: `Song` Catalog
+
+The song layer is separate from `ProjectState`.
+
+### What it owns
+
+- portfolio metadata
+- pointer to `projectStateId`
+- embedded MIDI payload
+- original MIDI filename
+
+### Why it matters product-wise
+
+- It defines the user's library and entry points.
+- It gives the app a "song portfolio" product shell.
+- It is not the actual editing source of truth for mappings or analysis.
+
+Evidence:
+
+- `src/types/song.ts`
+- `src/services/SongService.ts`
+
+## Derived State Systems
+
+### Active engine result
+
+- `ProjectContext.engineResult` is derived from:
+  - `projectState.solverResults[projectState.activeSolverId]`
+- This means the user-facing analysis surface depends on both stored results and which solver is selected.
+
+Evidence:
+
+- `src/context/ProjectContext.tsx`
+
+### Active performance
+
+- `getActivePerformance(projectState)` derives a filtered `Performance` based on `ignoredNoteNumbers`.
+- `getRawActivePerformance(projectState)` returns the unfiltered version.
+
+Evidence:
+
+- `src/utils/performanceSelectors.ts`
+
+### Workbench finger-assignment color map
+
+- `LayoutDesigner` derives `fingerAssignmentMap` from:
+  - `engineResult.debugEvents`
+  - `manualAssignments`
+  - filtered performance
+
+Evidence:
+
+- `src/workbench/LayoutDesigner.tsx`
+
+### Timeline finger labels
+
+- `TimelinePage` derives `fingerAssignments` from:
+  - `engineResult.debugEvents`
+  - active layout performance
+  - voices found in the active mapping
+
+Evidence:
+
+- `src/pages/TimelinePage.tsx`
+
+### Event-analysis models
+
+- Event Analysis derives:
+  - `AnalyzedEvent[]`
+  - `Transition[]`
+  - `OnionSkinModel`
+from current `engineResult` and `performance`.
+
+Evidence:
+
+- `src/workbench/EventAnalysisPanel.tsx`
+- `src/engine/eventMetrics.ts`
+- `src/engine/transitionAnalyzer.ts`
+- `src/engine/onionSkinBuilder.ts`
+
+## Persisted State
+
+### Portfolio persistence
+
+- Key: `push_perf_songs`
+- Contains:
+  - `Song` objects by ID
+
+### Per-song workbench persistence
+
+- Key format: `push_perf_project_<projectStateId>`
+- Contains:
+  - full `ProjectState`
+
+### Theme persistence
+
+- Key: `push_perf_theme`
+- Contains:
+  - `dark` or `light`
+
+### Project file persistence
+
+- Portable JSON export/import of `ProjectState`
+
+Evidence:
+
+- `src/services/SongService.ts`
+- `src/utils/projectPersistence.ts`
+- `src/context/ThemeContext.tsx`
+
+## Imported / Exported State
+
+| Import / export path | What enters or leaves the system | Canonical object touched |
+|---|---|---|
+| MIDI link to existing song | MIDI file in, derived `ProjectState` + metadata out | `Song`, `ProjectState` |
+| hidden direct MIDI import service path | MIDI file in, new `Song` + `ProjectState` out | `Song`, `ProjectState` |
+| Project JSON export/import | full project state in/out | `ProjectState` |
+| Event-analysis exports | analysis artifacts out only | derived event-analysis models |
+
+## Local State Patterns
+
+### Workbench local state
+
+Primarily visual or interaction state:
+
+- settings menu open/closed
+- show note labels
+- show position labels
+- show finger assignment overlay
+- selected solver
+- advanced mode toggle
+- solver progress
+- optimization loading state
+- song-local current ID ref handling
+
+Evidence:
+
+- `src/workbench/Workbench.tsx`
+
+### LayoutDesigner local state
+
+- selected sound or cell
+- drag state
+- left-tab choice
+- pose edit mode
+- active pose finger
+- preview offset
+- context menu state
+- reachability visualization state
+
+Evidence:
+
+- `src/workbench/LayoutDesigner.tsx`
+
+### Timeline local state
+
+- `currentTime`
+- `zoom`
+
+Evidence:
+
+- `src/pages/TimelinePage.tsx`
+
+### Event Analysis local state
+
+- left-panel tab
+- selected event index
+- practice-loop internal play state and interval refs
+
+Evidence:
+
+- `src/workbench/EventAnalysisPanel.tsx`
+- `src/hooks/usePracticeLoop.ts`
+
+## Duplicated or Mirrored State
+
+### `engineResult` vs `solverResults`
+
+Current code truth:
+
+- the canonical stored analysis results are `ProjectState.solverResults`
+- `engineResult` is a derived convenience selector
+
+Remaining confusion:
+
+- older docs and audits still describe an older dual-source model
+- `ProjectContext` still exposes a deprecated no-op `setEngineResult` for compatibility
+
+Evidence:
+
+- `src/context/ProjectContext.tsx`
+- stale contrast in `docs/PROJECT_OVERVIEW.md`, `docs/audit/02_state_and_dataflow.md`
+
+### Filtered performance vs raw performance
+
+- Filtered performance is used for analysis.
+- Raw performance is still used in some display or library contexts.
+
+Why this matters:
+
+- the user can hide voices without deleting them
+- some visualizations may diverge if they assume different source performance
+
+Evidence:
+
+- `src/utils/performanceSelectors.ts`
+- `src/workbench/VoiceLibrary.tsx`
+- `src/pages/TimelinePage.tsx`
+
+### Voice metadata across staging and mapping cells
+
+- Renaming/recoloring a voice updates:
+  - `parkedSounds`
+  - any matching mapped `Voice` instances in `GridMapping.cells`
+
+This is a synchronization pattern, not a purely normalized reference model.
+
+Evidence:
+
+- `src/workbench/Workbench.tsx:handleUpdateSound`
+- `src/workbench/Workbench.tsx:handleUpdateMappingSound`
+
+## State Ownership Confusion Points
+
+| Confusion point | Why it is confusing | Evidence |
+|---|---|---|
+| `layouts` vs `mappings` | One owns the performance, the other owns the placement, but product copy often just says "layout" for both | `src/types/projectState.ts`, `src/types/layout.ts`, Workbench copy |
+| `sectionMaps` presence | It lives in primary state but has little active UX behavior | `src/types/projectState.ts` |
+| `setInitialStateFromNeutralPose` mapping resolution | This context helper still falls back to the first mapping, unlike the stricter active-mapping model elsewhere | `src/context/ProjectContext.tsx` |
+| Event identity fallback | Manual assignments are intended to use `eventKey`, but some flows still fallback to stringified indices | `src/types/projectState.ts`, `src/workbench/EventLogTable.tsx` |
+
+## Likely Product-Facing Source-of-Truth Summary
+
+If a product designer or systems analyst needs the shortest true statement:
+
+1. `Song` is the portfolio container.
+2. `ProjectState` is the actual workbench source of truth.
+3. `Performance` plus `GridMapping` plus `NaturalHandPose` are the core domain inputs.
+4. `solverResults` is the durable analysis-result store.
+5. Most other important states are either:
+   - derived views of those objects, or
+   - local UI state for a given screen.
+
+## Implications for Future Product Artifacts
+
+- A product spec should explicitly separate:
+  - portfolio state
+  - musical input state
+  - mapping state
+  - personalization state
+  - analysis-result state
+- Any future UX architecture should make it obvious which object is being edited at each step.
+- Acceptance criteria should include cross-route consistency for `activeMappingId`, hidden-note filtering, and selected solver result.
+

--- a/docs/product-synthesis/USER_GOALS_AND_JOBS_TO_BE_DONE.md
+++ b/docs/product-synthesis/USER_GOALS_AND_JOBS_TO_BE_DONE.md
@@ -1,0 +1,99 @@
+# User Goals and Jobs To Be Done
+
+## Method
+
+This document separates:
+
+- Explicit user goals:
+  - Supported by visible labels, route names, docs, comments, or button text.
+- Implied user goals:
+  - Inferred from workflows, solver behavior, and data-model structure.
+- Ambiguity:
+  - Where the repo appears to support multiple competing user intents.
+
+## Explicit User Goals
+
+| Goal | Why it appears explicit | Evidence | Confidence |
+|---|---|---|---|
+| Manage a portfolio of songs | Dashboard is labeled "Song Portfolio" and stores multiple songs | `src/pages/Dashboard.tsx`, `src/types/song.ts` | High |
+| Link MIDI data to a song | Song card offers `Link MIDI` / `Re-link` | `src/components/dashboard/SongCard.tsx` | High |
+| Open a song in an editor | Song card action is labeled `Editor` and routes to `/workbench` | `src/components/dashboard/SongCard.tsx` | High |
+| Analyze event difficulty | Song card action is labeled `Analyze`; event route is titled `Event Analysis` | `src/components/dashboard/SongCard.tsx`, `src/pages/EventAnalysisPage.tsx` | High |
+| Configure a natural hand pose | Workbench pose panel is explicitly named `Natural Hand Pose` | `src/workbench/NaturalHandPosePanel.tsx` | High |
+| Assign sounds/voices to pads | Workbench has grid DnD and library tabs `Unassigned` / `Placed` | `src/workbench/LayoutDesigner.tsx`, `src/workbench/VoiceLibrary.tsx` | High |
+| Optimize the layout ergonomically | Toolbar button `Auto-Arrange`; summary shows `Ergonomic Score` | `src/workbench/Workbench.tsx`, `src/workbench/AnalysisPanel.tsx` | High |
+| Run analysis on the current layout | Toolbar button `Run Analysis` | `src/workbench/Workbench.tsx` | High |
+| Inspect transitions between events | Event-analysis screen exposes event timeline, onion skin, and transition metrics | `src/workbench/EventAnalysisPanel.tsx` | High |
+| Save and reload portable project files | Workbench exposes `Save Project` and `Load` | `src/workbench/Workbench.tsx` | High |
+
+## Implied User Goals
+
+| Goal | Why it is implied | Evidence | Confidence |
+|---|---|---|---|
+| Personalize the mapping process to the user's body | Pose 0 feeds deterministic assignment and solver neutral positions | `src/engine/handPose.ts`, `src/engine/seedMappingFromPose0.ts`, `src/context/ProjectContext.tsx` | High |
+| Achieve full note coverage before optimization | Optimization blocks when notes are unmapped | `src/workbench/Workbench.tsx`, `src/engine/mappingCoverage.ts` | High |
+| Compare solver strategies, not only final scores | Advanced mode stores and compares beam, genetic, and annealing outputs | `src/workbench/Workbench.tsx`, `src/workbench/AnalysisPanel.tsx` | Medium |
+| Inspect why a layout is difficult, not just that it is difficult | Cost breakdowns, transition metrics, and onion-skin visuals all explain causes | `src/pages/CostDebugPage.tsx`, `src/workbench/TransitionMetricsPanel.tsx`, `src/components/vis/OnionSkinGrid.tsx` | High |
+| Filter or simplify the performance before analyzing it | Ignored note numbers hide notes from filtered performance | `src/utils/performanceSelectors.ts`, `src/workbench/VoiceLibrary.tsx` | Medium |
+| Preserve work locally per song over time | Autosave is central and persistent | `src/workbench/Workbench.tsx`, `src/services/SongService.ts` | High |
+| Iterate on multiple layout variants | Duplicate mapping exists; version metadata exists; optimization rewrites mappings | `src/workbench/Workbench.tsx`, `src/types/layout.ts` | Medium |
+| Use the tool as a debugging / research instrument | Cost debug, fixture tests, debug events, annealing trace | `src/pages/CostDebugPage.tsx`, `src/engine/__tests__/*` | Medium |
+
+## Candidate Jobs To Be Done
+
+### Primary JTBD candidates
+
+1. When I have a MIDI performance I want to play on Push, I want to map its required notes onto pads so I can perform it with less physical strain.
+2. When a performance feels awkward on the grid, I want the system to show me why it is awkward so I can improve the layout instead of guessing.
+3. When my natural hand position differs from a default assumption, I want to define my own resting pose so the layout and finger suggestions fit my body.
+4. When there are too many ways to place sounds, I want the system to seed or optimize a plausible mapping so I can start from something workable.
+
+### Secondary JTBD candidates
+
+5. When I am comparing layout ideas, I want to duplicate, tweak, and evaluate mappings so I can decide which one is most playable.
+6. When I am practicing a difficult passage, I want to inspect difficult transitions and rehearse them at slower speeds so I can reduce failure points.
+7. When I want to keep my work organized by song, I want each song to preserve its own project state so I can return later without rebuilding context.
+8. When the solver makes a surprising choice, I want developer-grade debug information so I can understand the cost model and edge cases.
+
+## Primary vs Secondary Goals
+
+### Likely primary goals
+
+| Goal | Why it appears primary | Evidence |
+|---|---|---|
+| Build or improve a playable pad mapping for a performance | This is the center of the Workbench, data model, and engine | `src/workbench/Workbench.tsx`, `src/context/ProjectContext.tsx`, `README.md` |
+| Evaluate playability ergonomically | Scores, finger assignments, cost breakdowns, hand balance, difficulty views all support this | `src/workbench/AnalysisPanel.tsx`, `src/engine/core.ts`, `src/engine/costFunction.ts` |
+| Personalize mapping to user hand posture | Pose 0 influences seed, natural assignment, and solver | `src/workbench/NaturalHandPosePanel.tsx`, `src/engine/handPose.ts` |
+
+### Likely secondary or supporting goals
+
+| Goal | Why it appears secondary | Evidence |
+|---|---|---|
+| Track song practice progress | `SongMetadata` has practice/rating fields, but current UI uses only a thin slice of them | `src/types/song.ts`, `src/components/dashboard/SongCard.tsx` |
+| Rehearse transitions interactively | Practice loop exists, but it is visual stepping only | `src/hooks/usePracticeLoop.ts` |
+| Compare multiple solver families as a user-facing workflow | Advanced compare mode exists, but it is niche and hidden | `src/workbench/Workbench.tsx`, `src/workbench/AnalysisPanel.tsx` |
+| Operate on musical sections | `sectionMaps` exist but are not a live UX flow | `src/types/performance.ts`, `src/types/projectState.ts` |
+
+## Conflicts / Ambiguity
+
+### Persona ambiguity
+
+| Possible persona | Evidence | Conflict |
+|---|---|---|
+| Performing musician / finger drummer | Push grid model, ergonomic scoring, pose editing | Likely core persona |
+| Practice-tracking learner | Song metadata fields, status badges, "last practiced" | Current UX does not deeply support this persona |
+| Engine developer / ergonomics researcher | Cost Debug page, debug events, many tests | Real in codebase, but not clearly a product persona |
+
+### Goal ambiguity
+
+| Competing goal | Evidence | Why it matters |
+|---|---|---|
+| "Get me a layout fast" vs "Let me author deliberately" | Buttons for Seed, Natural, Random, Auto-Arrange coexist with detailed manual DnD | Product needs a clearer canonical path |
+| "Analyze current mapping" vs "Generate a new better one" | `Run Analysis` and `Auto-Arrange` sit together and both use solver logic | Users may conflate diagnosis with automated change |
+| "Song portfolio" vs "performance workbench" | Dashboard metadata model is rich; Workbench mostly cares about performance + mapping | Top-level product identity is split |
+| "Section layout optimizer" vs "song mapping tool" | Workbench header copy still says "Section Layout Optimizer" while live UX is song/mapping centric | Terminology shapes product expectations |
+
+## Evidence-Based Takeaway
+
+The clearest consistent user goal in the repo is not "music management" or "practice tracking." It is: take a MIDI-derived performance, place or optimize its voices on an 8x8 Push grid, and understand whether that mapping is physically workable for a particular player. Everything else appears secondary, partial, or historically layered on top of that core.
+

--- a/docs/product-synthesis/VISUALIZATION_AND_FEEDBACK_MODEL.md
+++ b/docs/product-synthesis/VISUALIZATION_AND_FEEDBACK_MODEL.md
@@ -1,0 +1,237 @@
+# Visualization and Feedback Model
+
+## Purpose
+
+This document describes how the current product communicates system state, playability, difficulty, and editing consequences to the user. It focuses on user-facing feedback loops, not internal rendering mechanics.
+
+## High-Level Feedback Pattern
+
+The current product communicates through a layered feedback stack:
+
+1. Structural state:
+   - which song is loaded
+   - whether MIDI is linked
+   - whether a mapping exists
+2. Mapping state:
+   - which voices are unassigned, placed, hidden, or locked
+3. Analysis state:
+   - ergonomic score
+   - finger assignments
+   - cost breakdowns
+   - hard/unplayable counts
+4. Temporal state:
+   - timeline ordering
+   - event transitions
+   - onion-skin before/after context
+5. Optimization state:
+   - layout mode
+   - solver comparison
+   - annealing progress
+
+## Dashboard Feedback
+
+### Visual signals used
+
+| Signal | What it tells the user | Evidence |
+|---|---|---|
+| Status badge `In Progress` | song was practiced recently | `src/components/dashboard/SongCard.tsx` |
+| Status badge `Mastered` | song has a high performance rating | same |
+| MIDI linked check indicator | song has MIDI attached | same |
+| Title and BPM display | minimal song identity | same |
+
+### What is missing or unclear
+
+- The Dashboard communicates portfolio status, but not mapping status.
+- There is no visible summary of whether a song already has a usable mapping or only linked MIDI.
+- Practice-oriented signals exist in metadata, but do not connect to a real practice route.
+
+## Workbench Grid Feedback
+
+### Grid-level visualizations
+
+| Visualization | Meaning | Evidence | Notes |
+|---|---|---|---|
+| Pad fill color by finger | which hand/finger is associated with the placed voice | `src/workbench/LayoutDesigner.tsx:fingerAssignmentMap` | One of the strongest immediate feedback loops |
+| Finger badge `L2`, `R3`, etc. | exact finger label for a placed pad | same | More explicit than color alone |
+| Finger-lock icon | a pad has a user-imposed finger lock | same | Good compact signal |
+| Pose ghost marker | pad participates in current Pose 0 preview or edit state | same plus `NaturalHandPosePanel` helpers | Bridges personalization and mapping |
+| Layout mode chip | whether layout is `Manual`, `Random`, `Optimized`, or `No Layout` | same | Important but still high-level |
+| Note labels / position labels | note names or grid coordinates shown on pads | `src/workbench/Workbench.tsx` settings + `LayoutDesigner` | Optional layer for expert inspection |
+| Reachability tint | green / yellow / gray reach zones from anchor pad | `src/engine/feasibility.ts`, `LayoutDesigner` | Hidden but valuable |
+
+### Feedback on manual edits
+
+- Dragging voices changes visible placement immediately.
+- Renaming or recoloring voices updates list and grid presentation.
+- Visibility toggle hides notes from filtered performance, indirectly changing later analysis.
+- Finger locks provide a persistent visual cue on the affected pad.
+
+### Feedback gaps
+
+- The system does not summarize "what changed" after a drag or batch assignment.
+- There is no explicit visualization of coverage status before optimization except via blocking alert when optimization is attempted.
+- The current grid does not directly visualize why a finger assignment is preferred, only the resulting assignment itself.
+
+## Workbench Analysis Feedback
+
+### Summary layer
+
+| Metric / visualization | Purpose | Evidence |
+|---|---|---|
+| Ergonomic score | top-level quality signal | `src/workbench/AnalysisPanel.tsx` |
+| Total events | scope of analyzed material | same |
+| Hand balance bar | left/right distribution | same |
+| Average movement/stretch/drift/bounce/fatigue/crossover | reveals what kind of strain is dominating | same |
+| Finger assignments table | maps analyzed usage back to notes/voices | `src/workbench/SoundAssignmentTable.tsx` |
+
+### Comparison layer
+
+| Visualization | Purpose | Evidence |
+|---|---|---|
+| Solver comparison table | compare beam vs genetic outcomes | `src/workbench/AnalysisPanel.tsx` |
+| Evolution graph | show genetic optimization progress over generations | same |
+
+### Optimization-process layer
+
+| Visualization | Purpose | Evidence |
+|---|---|---|
+| Annealing process graph | show search trajectory through optimization run | `src/workbench/AnalysisPanel.tsx` |
+| Initial/final cost, improvement, acceptance rate | summarize optimizer performance | same |
+
+### Feedback gaps
+
+- There is no explicit "analysis is stale / current / based on which solver" banner in the main summary area.
+- There is no compact explanation of how to interpret the ergonomic score scale.
+- Optimization feedback explains process after the fact, but not the preconditions the user should satisfy before running it.
+
+## Timeline Feedback
+
+### Visualizations used
+
+| Visualization | Meaning | Evidence |
+|---|---|---|
+| Voice lanes | which voices occur over time | `src/workbench/Timeline.tsx` |
+| Note blocks | event timing and duration | same |
+| Finger labels overlay | which finger is thought to play a given event | `src/pages/TimelinePage.tsx`, `Timeline.tsx` |
+| Zoom slider | density control for inspection | `src/pages/TimelinePage.tsx` |
+| Current time marker | current seek position | `src/workbench/Timeline.tsx` |
+
+### Feedback gaps
+
+- Timeline does not strongly indicate which mapping or solver result the finger labels came from.
+- It is useful as an overview, but not yet a rich practice-feedback surface.
+- There is no difficulty-strip or aggregated stress overlay over time.
+
+## Event Analysis Feedback
+
+### Event timeline panel
+
+| Visualization | Meaning | Evidence |
+|---|---|---|
+| Difficulty heat bars per transition | relative transition difficulty | `src/workbench/EventTimelinePanel.tsx` |
+| `from -> to` indices and timestamps | sequence and location in time | same |
+| hand-switch / finger-change tags | categorical difficulty flags | same |
+
+### Event log table
+
+| Visualization / control | Meaning | Evidence |
+|---|---|---|
+| sorted rows by cost | exposes hardest raw debug events first | `src/workbench/EventLogTable.tsx` |
+| hand selector | manual override control | same |
+| finger selector | manual override control | same |
+| cost colorization | rough severity cue | same |
+
+### Onion-skin grid
+
+| Visualization | Meaning | Evidence |
+|---|---|---|
+| current/previous/next pads | local temporal context | `src/components/vis/OnionSkinGrid.tsx`, `src/engine/onionSkinBuilder.ts` |
+| shared/current-only/next-only pads | continuity vs movement | `src/types/eventAnalysis.ts` |
+| vector arrows / finger moves | movement path between moments | same |
+
+### Transition metrics panel
+
+| Metric | Meaning | Evidence |
+|---|---|---|
+| Time Delta | speed demand | `src/workbench/TransitionMetricsPanel.tsx` |
+| Grid Distance | spatial movement size | same |
+| Composite and Stretch percentages | summary difficulty components | same |
+| Speed Pressure bar | urgency visualization | same |
+| Flags | hand switch / finger change | same |
+| Event details | pad count and sample pads | same |
+
+### Practice-loop feedback
+
+| Visualization / state | Meaning | Evidence |
+|---|---|---|
+| Play / Stop | whether loop stepping is active | `src/workbench/PracticeLoopControls.tsx` |
+| Looping transition `N -> N+1` label | focused transition | same |
+| Speed selector | relative stepping speed | same |
+| automatic event-index stepping | animated change of focus | `src/hooks/usePracticeLoop.ts` |
+
+### Feedback gaps
+
+- Practice-loop output is visual only; no audio/MIDI confirmation or embodied practice feedback exists.
+- Event Analysis is the best explanatory view, but still requires the user to mentally connect it back to actual mapping changes in Workbench.
+- There is no direct "apply suggestion" loop from hard transitions back into layout-edit recommendations.
+
+## Cost / Constraint Feedback
+
+### Constraint feedback currently shown
+
+| Feedback | Where | Current form |
+|---|---|---|
+| finger locks | Workbench grid | lock badge and context-menu active state |
+| reachability | Workbench grid | green/yellow/gray overlay by anchor |
+| unmapped-note optimization block | Workbench | alert dialog listing sample unmapped MIDI notes |
+| hard/unplayable counts | Event Analysis header, solver outputs | numeric summary |
+
+### Cost feedback currently shown
+
+| Feedback | Where | Current form |
+|---|---|---|
+| average cost components | Workbench analysis panel | metric grid |
+| per-event cost | Event log, Cost Debug | numeric per row/event |
+| cost breakdown components | Cost Debug | full component detail |
+| transition composite difficulty | Event timeline and metrics panel | percentages and heat bars |
+
+### Missing or unclear constraint feedback
+
+- No persistent coverage meter before optimization.
+- No explicit explanation of finger-lock consequences after applying them.
+- No visual comparison of current mapping cost vs prior mapping cost unless the user inspects annealing stats or advanced solver views.
+
+## Manual Edits vs Optimized Results
+
+### Current comparison cues
+
+| Cue | Meaning | Evidence |
+|---|---|---|
+| layout mode chip | rough origin of the current mapping | `LayoutDesigner` |
+| optimization tab | shows annealing process for optimized layout | `AnalysisPanel` |
+| solver selector | allows switching the currently viewed analysis result | Workbench advanced mode |
+
+### Missing comparison cues
+
+- No explicit diff view between pre- and post-optimization mappings.
+- No moved-pad count or changed-constraint count.
+- No stable "baseline vs candidate" side-by-side mapping workflow.
+
+## Overall Assessment
+
+The product already has a strong feedback vocabulary for expert users:
+
+- color
+- badges
+- metrics
+- transition heatmaps
+- onion-skin context
+- debug breakdowns
+
+Its main weakness is not lack of feedback, but lack of hierarchy and closure. The user gets many signals, but the app does not consistently tell them:
+
+- which signal matters most right now
+- whether the analysis is current
+- what concrete next action to take
+- how one screen's findings should feed the next editing action
+

--- a/docs/product-synthesis/WORKFLOW_AND_TASK_INVENTORY.md
+++ b/docs/product-synthesis/WORKFLOW_AND_TASK_INVENTORY.md
@@ -1,0 +1,783 @@
+# Workflow and Task Inventory
+
+## Workflow Map At A Glance
+
+```text
+Dashboard
+  -> Create song
+  -> Link MIDI
+  -> Open Workbench
+
+Workbench
+  -> Review imported voices / empty grid
+  -> Configure Natural Hand Pose (optional in UX, important in code)
+  -> Place voices manually or via Seed / Natural / Random
+  -> Run Analysis
+  -> Auto-Arrange
+  -> Iterate / save / export
+
+Drill-downs
+  -> Timeline View
+  -> Event Analysis
+  -> Cost Debug (dev only)
+```
+
+## Workflow 1: Create or Select a Song Container
+
+### Core task
+
+Create a song record or choose an existing one as the container for a performance-specific project state.
+
+### Entry points
+
+- Dashboard grid on `/`
+- Add New Song card in `src/pages/Dashboard.tsx`
+- Existing `SongCard` components
+
+### Prerequisite state/data
+
+- None for creating a new empty song
+- Existing `Song` data in localStorage for selecting a saved one
+
+### Inputs required
+
+- For empty song creation:
+  - none beyond default values
+- For existing song selection:
+  - selected song ID
+
+### Main actions
+
+1. Open Dashboard.
+2. Click an existing song card's `Editor` or `Analyze` action, or create a new song.
+
+### Outputs generated
+
+- New `Song` metadata entry, if created
+- Route transition to Workbench or Event Analysis, if selected
+
+### User decisions
+
+- Which song to work on
+- Whether to create a new shell before linking MIDI
+
+### What the system computes or visualizes
+
+- Song cards with title, BPM, status badge, MIDI-link indicator
+- Implicit per-song storage lookup
+
+### Success condition
+
+- The user has a song context selected
+
+### Failure / confusion points
+
+- Empty-song creation does not immediately guide the user to link MIDI.
+- Status badges imply practice semantics, but the main workflow after that is still mapping/analysis.
+
+### Files / routes / components involved
+
+- `/`
+- `src/pages/Dashboard.tsx`
+- `src/components/dashboard/SongCard.tsx`
+- `src/services/SongService.ts`
+
+## Workflow 2: Link MIDI to a Song
+
+### Core task
+
+Attach a MIDI file to a song so the system can derive a performance, voices, and initial project state.
+
+### Entry points
+
+- `Link MIDI` / `Re-link` control on each `SongCard`
+
+### Prerequisite state/data
+
+- A song must already exist
+
+### Inputs required
+
+- MIDI file chosen by the user
+
+### Main actions
+
+1. Click `Link MIDI` or `Re-link`.
+2. Choose a `.mid` or `.midi` file.
+3. Wait for parse and local persistence.
+
+### Outputs generated
+
+- Base64 MIDI stored in `Song`
+- `ProjectState` saved under `Song.projectStateId`
+- Imported `Performance`
+- `Voice[]`
+- Empty `GridMapping`
+- Default `NaturalHandPose`
+
+### User decisions
+
+- Which MIDI file belongs to which song
+
+### What the system computes or visualizes
+
+- MIDI parsing into note events
+- Voice extraction from unique note numbers
+- Bottom-left note adjustment
+- Key inference heuristic
+- Duration inference
+- MIDI-linked badge on Dashboard
+
+### Success condition
+
+- The song has a linked MIDI file and loadable project state
+
+### Failure / confusion points
+
+- Re-linking effectively rebuilds project state from MIDI, which may overwrite previous mapping work.
+- Import summary is not surfaced to the user; warnings such as out-of-range notes remain largely internal.
+
+### Files / routes / components involved
+
+- `/`
+- `src/components/dashboard/SongCard.tsx`
+- `src/pages/Dashboard.tsx:handleMidiLinked`
+- `src/services/SongService.ts:linkMidiToSong`
+- `src/utils/midiImport.ts`
+
+## Workflow 3: Hydrate Song State Into the Workbench
+
+### Core task
+
+Load the selected song's stored project state into the global project context.
+
+### Entry points
+
+- Workbench route `/workbench?songId=...`
+- Timeline route `/timeline?songId=...`
+- Event Analysis route `/event-analysis?songId=...`
+
+### Prerequisite state/data
+
+- A valid `songId`
+- Saved project state in localStorage, or seeded default test song
+
+### Inputs required
+
+- Query param `songId`
+
+### Main actions
+
+1. Route loads with `songId`.
+2. `useSongStateHydration(songId)` checks current in-memory data and localStorage.
+3. If needed, it loads saved state and calls `setProjectState(savedState, true)`.
+
+### Outputs generated
+
+- Global `ProjectState` hydrated into `ProjectContext`
+- `songName` metadata for page headers
+
+### User decisions
+
+- None during hydration
+
+### What the system computes or visualizes
+
+- Determines whether current context already has "real data"
+- Sets default `activeMappingId` if missing
+
+### Success condition
+
+- Workbench or analysis page reflects the selected song's actual saved state
+
+### Failure / confusion points
+
+- Hydration is implicit.
+- If the stored project state was built from an empty or stale song shell, routed pages may land in a "no MIDI data" state.
+
+### Files / routes / components involved
+
+- `src/hooks/useSongStateHydration.ts`
+- `src/context/ProjectContext.tsx`
+- `src/services/SongService.ts:loadSongState`
+
+## Workflow 4: Review Imported Material and Understand Initial State
+
+### Core task
+
+See what the imported MIDI produced and understand what needs to happen next.
+
+### Entry points
+
+- Workbench after hydration
+
+### Prerequisite state/data
+
+- Imported performance and voices
+
+### Inputs required
+
+- None
+
+### Main actions
+
+1. Enter the Workbench.
+2. Review `Voice Library` tabs:
+   - `Detected`
+   - `Unassigned`
+   - `Placed`
+3. Observe the grid state and layout mode.
+
+### Outputs generated
+
+- None; this is mainly orientation
+
+### User decisions
+
+- Whether to edit Pose first, drag manually, seed, use Natural, or optimize
+
+### What the system computes or visualizes
+
+- Empty grid after import
+- Voice counts in staging and detected-note list
+- Layout mode chip (`No Layout`)
+
+### Success condition
+
+- The user understands the imported material well enough to begin placing voices
+
+### Failure / confusion points
+
+- The repo intentionally uses an explicit empty-grid model, but the UI does not strongly teach that model.
+- Multiple next-step actions are available immediately.
+
+### Files / routes / components involved
+
+- `/workbench`
+- `src/workbench/Workbench.tsx`
+- `src/workbench/LayoutDesigner.tsx`
+- `src/workbench/VoiceLibrary.tsx`
+- `src/utils/midiImport.ts`
+
+## Workflow 5: Configure Natural Hand Pose
+
+### Core task
+
+Define where each finger naturally rests so the system can seed and evaluate layouts using a personalized baseline.
+
+### Entry points
+
+- Workbench left panel `Pose` tab
+
+### Prerequisite state/data
+
+- A current project state
+
+### Inputs required
+
+- Finger selections
+- Pad clicks on the grid
+- Optional preview offset changes
+
+### Main actions
+
+1. Open `Pose` tab.
+2. Enter edit mode.
+3. Select a finger with click or keyboard shortcut.
+4. Click pads on the grid to assign each finger.
+5. Optionally preview a vertical offset.
+6. Save and normalize pose.
+
+### Outputs generated
+
+- Updated `naturalHandPoses[0]`
+
+### User decisions
+
+- Which pads represent natural hand placement
+- Whether to use a lower or higher offset preview
+
+### What the system computes or visualizes
+
+- Assignment count
+- Safe offset range
+- Ghost markers on the grid
+- Validation against duplicate or off-grid assignments
+
+### Success condition
+
+- Pose 0 is saved and can be reused by later layout-generation actions
+
+### Failure / confusion points
+
+- The feature is well-developed, but its strategic importance is only implied.
+- Users may not understand that `Natural`, `Seed`, solver neutral positions, and `Auto-Arrange` all depend on this pose.
+
+### Files / routes / components involved
+
+- `/workbench`
+- `src/workbench/NaturalHandPosePanel.tsx`
+- `src/workbench/LayoutDesigner.tsx`
+- `src/types/naturalHandPose.ts`
+- `src/engine/handPose.ts`
+
+## Workflow 6: Build a Mapping Manually
+
+### Core task
+
+Place voices on pads by hand and refine their placement iteratively.
+
+### Entry points
+
+- Workbench library and grid
+
+### Prerequisite state/data
+
+- Voices in staging or already placed
+- Active mapping
+
+### Inputs required
+
+- Drag/drop actions
+- Optional renames, recolors, visibility toggles, finger locks
+
+### Main actions
+
+1. Drag voices from `Unassigned` to pads.
+2. Move or swap placed voices as needed.
+3. Rename/recolor voices if helpful.
+4. Hide some notes from analysis if desired.
+5. Apply finger locks or reachability inspection via context menu.
+
+### Outputs generated
+
+- Updated `GridMapping.cells`
+- Updated `layoutMode='manual'`
+- Possible updates to `fingerConstraints`, `ignoredNoteNumbers`, and voice metadata
+
+### User decisions
+
+- Which voice belongs on which pad
+- Which notes to hide
+- Which pads require finger locks
+
+### What the system computes or visualizes
+
+- Drag targets
+- Selected pad state
+- Context menu options
+- Finger-color overlays if analysis exists
+
+### Success condition
+
+- The user has a coherent mapping they want to analyze or optimize
+
+### Failure / confusion points
+
+- There are several edit surfaces for the same underlying voice data.
+- Hidden actions such as finger locks and reachability are powerful but not discoverable.
+- Visibility toggling and destructive event deletion live in the same library region, which can cause caution or confusion.
+
+### Files / routes / components involved
+
+- `/workbench`
+- `src/workbench/LayoutDesigner.tsx`
+- `src/workbench/VoiceLibrary.tsx`
+- `src/workbench/Workbench.tsx`
+
+## Workflow 7: Generate a Starting Mapping Automatically
+
+### Core task
+
+Use a helper rather than full manual placement to get to a workable starting layout.
+
+### Entry points
+
+- Workbench toolbar
+- Workbench settings menu
+
+### Prerequisite state/data
+
+- Imported performance
+- Active mapping
+- Sometimes a valid natural hand pose
+
+### Inputs required
+
+- Chosen helper action:
+  - `Seed`
+  - `Natural`
+  - `Random`
+  - `Organize by 4x4 Banks`
+
+### Main actions
+
+1. Choose the helper mode.
+2. System assigns voices according to that helper's rule set.
+
+### Outputs generated
+
+- Updated `GridMapping.cells`
+- Updated `layoutMode`
+
+### User decisions
+
+- Which assignment strategy to trust as a starting point
+
+### What the system computes or visualizes
+
+- `Seed`:
+  - full-coverage mapping driven by note frequency and pose anchor pads
+- `Natural`:
+  - fills pose pads first, then remaining pads deterministically
+- `Random`:
+  - random placement of unassigned voices only
+- `Organize by 4x4 Banks`:
+  - quadrant-based placement driven by note ranges
+
+### Success condition
+
+- The user gets a mapping they can inspect or refine
+
+### Failure / confusion points
+
+- The semantic differences between these helper actions are not strongly explained in UI copy.
+- `Seed` is especially important because it guarantees coverage for later optimization, but that is not obvious until optimization fails without it.
+
+### Files / routes / components involved
+
+- `src/workbench/Workbench.tsx`
+- `src/engine/seedMappingFromPose0.ts`
+- `src/utils/autoLayout.ts`
+- `src/types/naturalHandPose.ts`
+
+## Workflow 8: Run Analysis on the Current Mapping
+
+### Core task
+
+Evaluate the current mapping's playability.
+
+### Entry points
+
+- Workbench toolbar `Run Analysis`
+
+### Prerequisite state/data
+
+- Active performance
+- Optional active mapping
+
+### Inputs required
+
+- Solver choice when advanced mode is on
+
+### Main actions
+
+1. Click `Run Analysis`.
+2. Optionally choose `beam` or `genetic`.
+3. Review results in the right-hand analysis panel.
+
+### Outputs generated
+
+- `EngineResult`
+- Stored solver result under `solverResults[solverType]`
+- `activeSolverId`
+
+### User decisions
+
+- Whether to use only default beam analysis or compare solver families
+
+### What the system computes or visualizes
+
+- Ergonomic score
+- Hand balance
+- Average cost components
+- Finger usage
+- Optional solver comparison graphs
+
+### Success condition
+
+- User can interpret whether the mapping is acceptable, hard, or poor
+
+### Failure / confusion points
+
+- The button says `Run Analysis`, but the product also has layout optimization and several analysis routes.
+- Advanced comparison is powerful but niche.
+
+### Files / routes / components involved
+
+- `/workbench`
+- `src/workbench/Workbench.tsx`
+- `src/context/ProjectContext.tsx:runSolver`
+- `src/workbench/AnalysisPanel.tsx`
+
+## Workflow 9: Optimize the Mapping
+
+### Core task
+
+Have the system rearrange the layout to reduce ergonomic cost.
+
+### Entry points
+
+- Workbench toolbar `Auto-Arrange`
+
+### Prerequisite state/data
+
+- Active mapping
+- Assigned sounds on the grid
+- Performance data
+- Full note coverage
+
+### Inputs required
+
+- Current mapping and performance
+
+### Main actions
+
+1. Click `Auto-Arrange`.
+2. System validates there is performance data, placed sounds, and full coverage.
+3. Annealing solver runs.
+4. Best mapping overwrites the current mapping.
+
+### Outputs generated
+
+- Updated mapping cells
+- `layoutMode='optimized'`
+- incremented `version`
+- `savedAt`
+- annealing result stored under `solverResults['annealing']`
+
+### User decisions
+
+- Whether the current layout is ready for optimization
+
+### What the system computes or visualizes
+
+- Best mapping found by annealing
+- Optimization trace and stats in analysis panel
+
+### Success condition
+
+- User receives a new optimized layout and can assess it
+
+### Failure / confusion points
+
+- Optimization overwrites the mapping in place.
+- Product protects against incomplete coverage, but only after the user attempts the action.
+- Users may not understand whether optimization respects Pose 0. In code, it does.
+
+### Files / routes / components involved
+
+- `/workbench`
+- `src/workbench/Workbench.tsx:handleOptimizeLayout`
+- `src/context/ProjectContext.tsx:optimizeLayout`
+- `src/engine/mappingCoverage.ts`
+- `src/engine/solvers/AnnealingSolver.ts`
+
+## Workflow 10: Inspect the Result Through Timeline View
+
+### Core task
+
+See the mapped performance in chronological form.
+
+### Entry points
+
+- Workbench header link `Timeline View`
+- direct route `/timeline?songId=...`
+
+### Prerequisite state/data
+
+- Hydrated project state
+- Active layout and mapping
+
+### Inputs required
+
+- Optional zoom changes
+- click-to-seek on the timeline
+
+### Main actions
+
+1. Open timeline route.
+2. Adjust zoom.
+3. Inspect voice lanes and finger labels.
+4. Click to seek current time marker.
+
+### Outputs generated
+
+- None persisted
+
+### User decisions
+
+- Which zoom level to use
+- Which time region to inspect
+
+### What the system computes or visualizes
+
+- Voices extracted from active mapping
+- Finger labels derived from `engineResult.debugEvents`
+- Chronological lane rendering of events
+
+### Success condition
+
+- User can understand sequence, density, and finger labeling over time
+
+### Failure / confusion points
+
+- Finger labels are a derived overlay and may be fragile if analysis state and performance filtering diverge.
+- Current route is simpler than some older docs imply; it is more an inspection view than a practice mode.
+
+### Files / routes / components involved
+
+- `/timeline`
+- `src/pages/TimelinePage.tsx`
+- `src/workbench/Timeline.tsx`
+
+## Workflow 11: Deep-Dive Event and Transition Analysis
+
+### Core task
+
+Inspect difficult moments and transitions in detail.
+
+### Entry points
+
+- Song card `Analyze`
+- Workbench header `Event Analysis`
+- direct route `/event-analysis?songId=...`
+
+### Prerequisite state/data
+
+- Hydrated project state
+- Available `engineResult`
+- Performance events
+
+### Inputs required
+
+- Transition selection
+- Optional keyboard up/down navigation
+- Optional manual hand/finger override from event log
+
+### Main actions
+
+1. Open Event Analysis.
+2. Select a transition in the left panel.
+3. Observe onion-skin grid and transition metrics.
+4. Optionally switch to event log and edit assignments.
+5. Optionally use practice-loop stepping.
+6. Optionally export JSON artifacts.
+
+### Outputs generated
+
+- Optional updated `manualAssignments`
+- Optional exported JSON files
+
+### User decisions
+
+- Which transition to focus on
+- Whether to override a hand/finger choice
+- Whether to export detailed analysis
+
+### What the system computes or visualizes
+
+- Grouped events via `analyzeEvents`
+- Transitions via `analyzeAllTransitions`
+- Onion-skin model via `buildOnionSkinModel`
+- Difficulty summary in header
+
+### Success condition
+
+- User can identify and reason about hard event-to-event movements
+
+### Failure / confusion points
+
+- This route overlaps conceptually with Workbench analysis and Timeline.
+- Practice loop implies rehearsal support but currently only flips selection index on a timer.
+
+### Files / routes / components involved
+
+- `/event-analysis`
+- `src/pages/EventAnalysisPage.tsx`
+- `src/workbench/EventAnalysisPanel.tsx`
+- `src/engine/eventMetrics.ts`
+- `src/engine/transitionAnalyzer.ts`
+- `src/engine/onionSkinBuilder.ts`
+
+## Workflow 12: Save, Load, and Export
+
+### Core task
+
+Preserve or move the current project or analysis artifacts.
+
+### Entry points
+
+- Workbench header `Save Project`
+- Workbench header `Load`
+- Event-analysis export buttons
+
+### Prerequisite state/data
+
+- Existing project state for save/export
+- Valid JSON file for load
+
+### Inputs required
+
+- JSON file for project load
+
+### Main actions
+
+1. Save full project as JSON, or let autosave persist locally.
+2. Load project JSON when desired.
+3. Export event-analysis JSON artifacts from Event Analysis.
+
+### Outputs generated
+
+- `project.json`
+- event metrics JSON
+- hard transitions JSON
+- practice loop settings JSON
+
+### User decisions
+
+- Whether they want portable project state or song-local autosave only
+- Which analysis artifact to export
+
+### What the system computes or visualizes
+
+- Strict validation for portable project import
+- Lenient validation for localStorage hydration
+
+### Success condition
+
+- User can recover, move, or inspect work outside the app
+
+### Failure / confusion points
+
+- The app uses multiple persistence modes without a unified mental model.
+- Project export/import and analysis export are separate, but this is not framed as a coherent artifact system.
+
+### Files / routes / components involved
+
+- `src/workbench/Workbench.tsx`
+- `src/utils/projectPersistence.ts`
+- `src/workbench/EventAnalysisPanel.tsx`
+- `src/utils/eventExport.ts`
+
+## Workflow Duplication / Reconnection Notes
+
+### Where workflows duplicate each other
+
+- Analysis summary exists in Workbench and again in Event Analysis.
+- Timeline is a separate route rather than a drill-down embedded in a single analysis hierarchy.
+- Voice editing can happen in grid cells, staged list items, and placed list items.
+
+### Where workflows reconnect
+
+- Event Analysis and Timeline both depend on the same hydrated `ProjectState` and current `engineResult`.
+- Most routes reconnect through `songId` and `useSongStateHydration`.
+- Workbench remains the main source of authoring changes even when analysis routes are used for inspection.
+
+### Where workflows are incomplete, confusing, or dead-ended
+
+- New empty song -> no immediate guidance to link MIDI.
+- Event-analysis practice loop -> no real playback.
+- Template-driven or section-driven workflows -> implied by models, not live in routed UX.
+- Direct import of new song from MIDI -> implemented in service, not exposed in current Dashboard UI.
+


### PR DESCRIPTION
## Summary
- add a first-draft product synthesis package under `docs/product-synthesis/`
- translate current repository behavior into product-definition artifacts grounded in source, routes, state, engine logic, tests, and existing docs
- explicitly separate code-backed truth from inference, ambiguity, duplication, and stale-document drift

## Included artifacts
- `PRODUCT_OVERVIEW_FIRST_DRAFT.md`
- `FEATURE_INVENTORY.md`
- `USER_GOALS_AND_JOBS_TO_BE_DONE.md`
- `WORKFLOW_AND_TASK_INVENTORY.md`
- `SCREEN_ROUTE_AND_PANEL_MAP.md`
- `DOMAIN_MODEL_AND_TERMINOLOGY.md`
- `CONSTRAINTS_CONSTANTS_AND_INVARIANTS.md`
- `STATE_SYSTEMS_AND_SOURCE_OF_TRUTH.md`
- `VISUALIZATION_AND_FEEDBACK_MODEL.md`
- `GAPS_DUPLICATIONS_AND_PRODUCT_CONFUSION.md`
- `ARTIFACT_INPUTS_CHECKLIST.md`
- `RECOMMENDED_NEXT_ARTIFACTS.md`

## What this PR does
- documents the current product as it actually exists in the repo today rather than proposing a redesign
- captures likely users, jobs to be done, workflows, routes, domain objects, constraints, state ownership, and feedback patterns
- calls out contradictions across code, tests, and docs, including dormant concepts such as `sectionMaps`, hidden capabilities such as direct MIDI import service paths, and overlapping analysis surfaces across Workbench, Timeline, Event Analysis, and Cost Debug
- ends the overview with the highest-value human product decisions still needed before UX architecture or mockups should be finalized

## Evidence basis
This package was synthesized from the active implementation and supporting repo material, including:
- routing and page entry points in `src/main.tsx` and `src/pages/*`
- Workbench orchestration and editor surfaces in `src/workbench/*`
- shared state and hydration in `src/context/*` and `src/hooks/*`
- domain types and persistence in `src/types/*`, `src/services/SongService.ts`, and `src/utils/*`
- solver, optimization, and event-analysis logic in `src/engine/*`
- existing repo docs and milestone notes in `README.md`, `docs/*`, and `PRD/*`
- current tests in `src/engine/__tests__/*`

## Validation notes captured in the docs
- `npm run test:run` currently fails; the synthesis docs treat that as evidence of model drift and unresolved implementation instability
- `npm run build` currently fails; those failures are documented as part of the current repo-health picture
- no application code was changed in this PR; this is a docs-only synthesis package

## Why this is useful
This PR creates the missing bridge artifacts between the product idea and the current implementation so future human + LLM work can proceed in the right order:
1. mission and goals
2. terminology and domain canon
3. workflow and screen architecture
4. task-based UX specs
5. wireframe brief and QA criteria

## Scope boundary
- no product redesign
- no code refactor
- no workflow rewrite
- no implementation changes outside adding the markdown synthesis package