### PR TITLE
Add product synthesis audit deliverables

### DIFF
--- a/DESIGN_GAPS.md
+++ b/DESIGN_GAPS.md
@@ -1,0 +1,226 @@
+# Design Gaps
+
+## Goal
+
+These are the product-design artifacts still missing between idea, UI, and code. They are the documents or models that should exist before a serious UI redesign, because the current repository contains implementation and screens but still lacks a stable product contract.
+
+## Gap 1: Canonical User Journey
+
+Why it is missing:
+
+- The app supports several valid first moves after MIDI import: manual drag/drop, Seed, Natural, Random, Run Analysis, or Auto-Arrange.
+- The code implements these options, but the product does not define which path is primary.
+
+Evidence:
+
+- Workbench toolbar exposes multiple "first step" actions side by side.
+- Import intentionally leaves the grid empty.
+
+Artifact needed:
+
+- A single canonical journey map from Dashboard -> MIDI link -> pose setup -> mapping -> analysis -> optimization -> validation.
+
+## Gap 2: Screen Responsibility Contract
+
+Why it is missing:
+
+- Analysis is split across Workbench, Timeline, Event Analysis, and Cost Debug.
+- The repo has screens, but not a single contract explaining what each screen is for and what it is not for.
+
+Evidence:
+
+- Workbench already contains summary analysis.
+- Timeline and Event Analysis both inspect solver output from different angles.
+- Cost Debug overlaps with both at a lower level.
+
+Artifact needed:
+
+- A screen responsibility matrix defining primary task, depth, and allowed actions per route.
+
+## Gap 3: Canonical Product Object Model
+
+Why it is missing:
+
+- The codebase mixes `song`, `project`, `layout`, `mapping`, `performance`, and `section` language.
+- Durable and derived objects are implemented, but not canonically described in one place.
+
+Evidence:
+
+- `Song` is dashboard-facing.
+- `ProjectState` is the real editing truth.
+- `LayoutSnapshot` stores the performance.
+- `GridMapping` is the editable layout.
+- `sectionMaps` still exist despite weak UI presence.
+
+Artifact needed:
+
+- A product-facing domain source-of-truth document with durable vs derived objects and ownership.
+
+## Gap 4: Interaction Model for Layout Authoring
+
+Why it is missing:
+
+- The grid editor supports drag/drop, swap, unassign, finger locks, reachability view, hide note, destructive delete, and pose edit mode.
+- Those interactions exist in code but do not have an explicit interaction model or precedence chart.
+
+Evidence:
+
+- `LayoutDesigner` owns many overlapping gestures and states.
+- Context menu behavior and pose edit mode compete for grid clicks.
+
+Artifact needed:
+
+- An interaction specification for the grid canvas, library, context menu, and pose-edit states.
+
+## Gap 5: Mapping Generation Decision Model
+
+Why it is missing:
+
+- `Seed`, `Natural`, `Random`, and `Auto-Arrange` are materially different operations.
+- The system does not define them as a staged model.
+
+Evidence:
+
+- Some actions create coverage.
+- Some only place unassigned voices.
+- Some analyze.
+- Some overwrite the mapping.
+
+Artifact needed:
+
+- A decision model that defines:
+  - when to use each action
+  - whether it is additive or destructive
+  - whether full note coverage is required
+
+## Gap 6: Visualization Semantics Spec
+
+Why it is missing:
+
+- Heatmaps, finger colors, difficulty bands, ghost pads, shared pads, and cost colors are implemented but not formally specified.
+
+Evidence:
+
+- Workbench colors grid pads from finger or difficulty data.
+- Event Analysis uses transition bars and onion-skin states.
+- Cost Debug uses separate cost-oriented visual language.
+
+Artifact needed:
+
+- A visualization semantics guide that defines what each color, opacity, badge, and score means across screens.
+
+## Gap 7: State Ownership and Sync Diagram
+
+Why it is missing:
+
+- The app behaves as a multi-route single-project workspace, but ownership rules are only implicit in code.
+
+Evidence:
+
+- `ProjectState` is canonical.
+- `engineResult` is derived.
+- `activeMappingId` is expected to stay consistent across routes.
+- hydration logic and autosave are route-sensitive.
+
+Artifact needed:
+
+- A source-of-truth and sync diagram showing:
+  - what is canonical
+  - what is derived
+  - what is persisted
+  - what is transient view state
+
+## Gap 8: Persistence Mental Model
+
+Why it is missing:
+
+- The app has song-local autosave, project JSON import/export, and analysis JSON export, but no single user-facing persistence model.
+
+Evidence:
+
+- Dashboard implies a song library.
+- Workbench implies a project file workflow.
+- Event Analysis exposes its own exports.
+
+Artifact needed:
+
+- A persistence model that explains what is saved automatically, what is exported manually, and what belongs to a song versus a portable file.
+
+## Gap 9: Error and Empty-State Catalog
+
+Why it is missing:
+
+- The app has many important blockers and preconditions, but mostly exposes them through inline messages or alerts.
+
+Evidence:
+
+- No song selected.
+- No MIDI linked.
+- No active mapping.
+- No coverage for optimization.
+- No Pose 0 for pose-based helpers.
+- No solver result for analysis pages.
+
+Artifact needed:
+
+- A screen-by-screen empty/error/precondition catalog with copy, cause, next step, and recovery path.
+
+## Gap 10: Measurement Dictionary
+
+Why it is missing:
+
+- The product exposes many scores, but their meanings are scattered across solver code and panels.
+
+Evidence:
+
+- Ergonomic score
+- hard/unplayable counts
+- average movement/stretch/drift/bounce/fatigue/crossover
+- transition composite difficulty
+- speed pressure
+- hand balance
+
+Artifact needed:
+
+- A metric dictionary that defines every displayed score, formula source, range, and intended user interpretation.
+
+## Gap 11: Component Contracts for Redesign
+
+Why it is missing:
+
+- Major UI regions exist, but their responsibilities are still encoded in implementation rather than in reusable contracts.
+
+Evidence:
+
+- `LayoutDesigner`, `AnalysisPanel`, `EventAnalysisPanel`, and `Timeline` are all doing conceptually stable work, but without redesign-ready interface specs.
+
+Artifact needed:
+
+- Component contracts describing each major surface's inputs, outputs, states, and edge cases.
+
+## Gap 12: Product Vocabulary Canon
+
+Why it is missing:
+
+- The codebase has improved terminology, but user-facing language is still split.
+
+Evidence:
+
+- "Song Portfolio" on the dashboard.
+- "Section Layout Optimizer" in the workbench header.
+- `layout`, `mapping`, and `performance` are not consistently distinguished in UI language.
+
+Artifact needed:
+
+- A short vocabulary canon for UI copy, docs, and future design work.
+
+## Highest-Priority Missing Artifacts Before UI Redesign
+
+1. Canonical user journey
+2. Screen responsibility contract
+3. Product object model
+4. Layout-authoring interaction model
+5. Visualization semantics spec
+6. State ownership and persistence model
+
+Without these, a redesign would likely re-skin the current implementation without resolving the product ambiguity already present in the repository.

--- a/DOMAIN_MODEL.md
+++ b/DOMAIN_MODEL.md
@@ -1,0 +1,126 @@
+# Domain Model
+
+## Canonical Domain Layers
+
+Durable stored objects:
+
+- `Song`
+- `ProjectState`
+- `LayoutSnapshot`
+- `Performance`
+- `NoteEvent`
+- `InstrumentConfig`
+- `GridMapping`
+- `Voice`
+- `NaturalHandPose`
+- `EngineConfiguration`
+
+Stored computed objects:
+
+- `EngineResult`
+- `EngineDebugEvent`
+
+Derived analysis objects:
+
+- `AnalyzedEvent`
+- `Transition`
+- `OnionSkinModel`
+
+Dormant or weakly active objects:
+
+- `SectionMap`
+- `LayoutTemplate`
+
+## Canonical Relationship Diagram
+
+```mermaid
+flowchart LR
+  song["Song"] --> project["ProjectState"]
+  project --> layout["LayoutSnapshot"]
+  layout --> performance["Performance"]
+  performance --> noteEvent["NoteEvent"]
+
+  project --> instrument["InstrumentConfig"]
+  project --> mapping["GridMapping"]
+  project --> voice["Voice"]
+  mapping --> voice
+
+  project --> pose["NaturalHandPose (Pose 0)"]
+  project --> engineConfig["EngineConfiguration"]
+  project --> solverResult["EngineResult"]
+  solverResult --> debugEvent["EngineDebugEvent"]
+
+  debugEvent --> analyzed["AnalyzedEvent"]
+  analyzed --> transition["Transition"]
+  analyzed --> onion["OnionSkinModel"]
+  transition --> onion
+```
+
+## Durable Objects
+
+| Object | Key fields | Relationships | Lifecycle |
+|---|---|---|---|
+| `Song` | `metadata`, `sections`, `projectStateId`, `midiData`, `midiFileName` | Owns a reference to one persisted `ProjectState` | Created from dashboard or MIDI import, updated via metadata edits and MIDI linking, deleted from dashboard |
+| `SongMetadata` | `id`, `title`, `artist`, `bpm`, `key`, `duration`, `lastPracticed`, `performanceRating`, `difficulty` | Embedded in `Song` | Created with song, lightly edited in dashboard, updated on auto-save or MIDI link |
+| `ProjectState` | `layouts`, `instrumentConfigs`, `instrumentConfig`, `activeLayoutId`, `activeMappingId`, `parkedSounds`, `mappings`, `ignoredNoteNumbers`, `manualAssignments`, `engineConfiguration`, `solverResults`, `activeSolverId`, `naturalHandPoses` | Central hub tying together imported material, authored mappings, solver output, and personalization | Created on MIDI link/import, hydrated into context, mutated during editing, serialized to local storage and JSON |
+| `LayoutSnapshot` | `id`, `name`, `performance`, `createdAt` | Owned by `ProjectState`; wraps one imported `Performance` | Created on MIDI import or full project load; remains the anchor for active performance selection |
+| `Performance` | `events`, `tempo`, `name` | Owned by `LayoutSnapshot`; composed of `NoteEvent[]` | Created from MIDI parsing, filtered for analysis by selectors, may be destructively edited when notes are deleted |
+| `NoteEvent` | `noteNumber`, `startTime`, `duration`, `velocity`, `channel`, `eventKey` | Member of `Performance.events`; solver input unit | Created by MIDI parser, used for mapping coverage and solver analysis, survives as raw musical truth |
+| `InstrumentConfig` | `id`, `name`, `rows`, `cols`, `bottomLeftNote`, `layoutMode` | Used by mapping resolution, grid labeling, and solver geometry | Created or derived during import, generally treated as single active config |
+| `Voice` | `id`, `name`, `sourceType`, `sourceFile`, `originalMidiNote`, `color` | Stored in `parkedSounds` and referenced by `GridMapping.cells` | Created from unique notes during import or seeded mapping creation, then edited, placed, hidden, or deleted |
+| `GridMapping` | `id`, `name`, `cells`, `fingerConstraints`, `scoreCache`, `notes`, `layoutMode`, `version`, `savedAt` | Maps pads to `Voice`; used by timeline, event analysis, and solvers | Starts empty on import, then filled manually or by helper, duplicated, optimized, cleared, and persisted |
+| `NaturalHandPose` | `version`, `name`, `positionIndex`, `fingerToPad`, `maxUpShiftRows`, `updatedAt` | Stored in `ProjectState.naturalHandPoses`; feeds seeding and neutral pad override | Defaulted on import, edited in workbench, validated and normalized, then reused by solver and auto-layout flows |
+| `EngineConfiguration` | `beamWidth`, `stiffness`, `restingPose` | Used when running solver strategies | Created from defaults, carried in `ProjectState`, applied at analysis time |
+| `SectionMap` | `id`, `name`, `startMeasure`, `lengthInMeasures`, `instrumentConfig` | Present in type system and project state | Imported or stored, but largely dormant in the current UI |
+
+## Computed and Stored Analysis Objects
+
+| Object | Key fields | Relationships | Lifecycle |
+|---|---|---|---|
+| `EngineResult` | `score`, `unplayableCount`, `hardCount`, `debugEvents`, `fingerUsageStats`, `fatigueMap`, `averageDrift`, `averageMetrics`, optional `evolutionLog`, `optimizationLog`, `annealingTrace`, `metadata` | Stored under `ProjectState.solverResults`; selected via `activeSolverId` | Produced by beam, genetic, or annealing flows; persisted with project state; reused across routes |
+| `EngineDebugEvent` | `noteNumber`, `startTime`, `assignedHand`, `finger`, `cost`, `costBreakdown`, `difficulty`, `row`, `col`, `eventIndex`, `padId`, `eventKey` | Member of `EngineResult.debugEvents`; basis for deeper analysis | Created by solver execution; used by workbench coloring, timeline labels, event log, and debug pages |
+| `ManualAssignment` | `eventKey -> { hand, finger }` within `manualAssignments[layoutId]` | Overrides a specific event's solver assignment | Created from Event Analysis or neutral-pose seeding, then read back during future solver runs and UI coloring |
+
+## Derived Analysis Objects
+
+| Object | Key fields | Relationships | Lifecycle |
+|---|---|---|---|
+| `AnalyzedEvent` | `eventIndex`, `timestamp`, `notes`, `pads`, `eventMetrics` | Derived by grouping `EngineDebugEvent`s with near-identical timestamps | Recomputed on Event Analysis page from the current engine result |
+| `Transition` | `fromIndex`, `toIndex`, `fromEvent`, `toEvent`, `metrics` | Connects consecutive `AnalyzedEvent`s | Recomputed whenever analyzed events change |
+| `TransitionMetrics` | `timeDeltaMs`, `gridDistance`, `handSwitch`, `fingerChange`, `speedPressure`, `anatomicalStretchScore`, `compositeDifficultyScore` | Embedded in `Transition` | Computed during transition analysis; displayed in panels and heatmaps |
+| `OnionSkinModel` | `currentEventIndex`, `currentEvent`, `previousEvent`, `nextEvent`, `sharedPads`, `currentOnlyPads`, `nextOnlyPads`, `fingerMoves` | Built from `AnalyzedEvent[]` and `Transition[]` | Recomputed for the focused event in Event Analysis |
+| `FingerMove` | `finger`, `hand`, `fromPad`, `toPad`, `isHold`, `isImpossible`, `rawDistance`, `anatomicalStretchScore` | Embedded in `OnionSkinModel` | Derived for visualization vectors between current and next event |
+
+## State Ownership
+
+Primary ownership:
+
+- `ProjectState` is the canonical source of truth for editable product state.
+
+Secondary durable ownership:
+
+- `Song` is the portfolio shell and persistence anchor.
+
+Derived ownership:
+
+- `engineResult` is a convenience selector, not an independent domain object.
+- filtered performance is a view over `Performance` plus `ignoredNoteNumbers`.
+
+## Lifecycle Narrative
+
+1. A `Song` is created or selected.
+2. MIDI import generates a `Performance`, `Voice[]`, `InstrumentConfig`, and empty `GridMapping`.
+3. Those objects are packed into a fresh `ProjectState`.
+4. The user edits `GridMapping`, `ignoredNoteNumbers`, and `NaturalHandPose`.
+5. Solver execution produces an `EngineResult`.
+6. Event-analysis pages derive `AnalyzedEvent`, `Transition`, and `OnionSkinModel` from that result.
+7. The full project state is auto-saved back to the song and can be exported as JSON.
+
+## Canonical Domain Invariants
+
+- `ProjectState.activeLayoutId` should point to the performance being analyzed.
+- `ProjectState.activeMappingId` should point to the mapping being visualized across routes.
+- `GridMapping.cells` keys must remain `"row,col"`.
+- `Performance.events` must remain sorted by `startTime`.
+- `naturalHandPoses[0]` is the app's Pose 0 contract.
+- Optimization requires full note coverage in the active mapping.

--- a/FEATURE_INVENTORY.md
+++ b/FEATURE_INVENTORY.md
@@ -1,0 +1,95 @@
+# Feature Inventory
+
+## Scope
+
+This inventory reflects features that are present in the current repository, grouped by product importance and maturity. "Core" means required for the main performance-to-layout workflow. "Secondary" means supporting but not essential. "Debug / Developer Tools" are intentionally diagnostic. "Experimental" captures hidden, weakly integrated, or dormant capabilities.
+
+## Core Features
+
+| Feature | Current behavior | Primary entry points |
+|---|---|---|
+| Song portfolio | Lists persisted songs and acts as app home | `src/pages/Dashboard.tsx` |
+| Create song container | Creates a new song with default metadata | Dashboard "Add New Song" |
+| MIDI link / re-link | Attaches MIDI to an existing song and regenerates song state | `SongCard`, `SongService.linkMidiToSong` |
+| Built-in default test song | Seeds a default MIDI-backed song on startup | `songService.seedDefaultTestSong()` |
+| Song-specific hydration | Loads a song's persisted `ProjectState` when entering routed pages | `useSongStateHydration` |
+| Per-song auto-save | Saves workbench state back to the selected song | `Workbench`, `SongService.saveSongState` |
+| Explicit empty-grid import | Imported voices go to staging; grid starts empty | `midiImport.ts`, `SongService.createProjectStateFromMidi` |
+| Voice library / staging area | Shows unassigned voices for drag-and-drop layout authoring | `VoiceLibrary` |
+| Manual drag-and-drop layout editing | Assign, move, swap, and unassign voices on the grid | `LayoutDesigner` |
+| Layout clearing | Removes all assignments from the current mapping | Workbench "Clear Grid" |
+| Natural Hand Pose editor | Lets the user define personalized finger resting pads | `NaturalHandPosePanel` |
+| Pose-based full seeding | Fills a mapping from Pose 0 anchors and performance note importance | Workbench "Seed" |
+| Pose-priority assignment | Places unassigned voices onto Pose 0 pads first | Workbench "Natural" |
+| Random assignment | Places remaining unassigned voices onto empty pads randomly | Workbench "Random" |
+| 4x4 bank organization | Maps notes into Push-style quadrant banks | Workbench settings "Organize by 4x4 Banks" |
+| Run analysis | Executes solver analysis against current mapping/performance | Workbench "Run Analysis" |
+| Biomechanical beam solver | Default ergonomic scoring and assignment engine | `ProjectContext.runSolver`, `BeamSolver` |
+| Simulated annealing layout optimization | Mutates mappings to reduce ergonomic cost | Workbench "Auto-Arrange", `ProjectContext.optimizeLayout` |
+| Solver-result persistence | Stores results by solver type in project state | `ProjectState.solverResults` |
+| Analysis summary | Shows ergonomic score, event count, hand balance, and metric averages | `AnalysisPanel` |
+| Sound-to-finger assignment table | Summarizes placed sounds, pads, and most common finger assignment | `SoundAssignmentTable` |
+| Timeline view | Displays voices as time lanes with finger labels | `/timeline`, `Timeline` |
+| Event analysis view | Displays grouped events, transitions, onion skin, and metrics | `/event-analysis`, `EventAnalysisPanel` |
+| Project JSON save/load | Exports and imports full project state | `projectPersistence.ts`, Workbench header |
+| Undo / redo | Maintains in-session project history | `useProjectHistory`, Workbench header |
+| Theme toggle | Toggles light/dark theme and persists it | `ThemeContext`, `ThemeToggle` |
+
+## Secondary Features
+
+| Feature | Current behavior | Primary entry points |
+|---|---|---|
+| Song metadata editing | Inline rename and BPM edit on song cards | `SongCard` |
+| Song deletion | Removes song metadata and its associated project state | `SongCard`, `SongService.deleteSong` |
+| Voice rename / recolor | Edits voice names and colors in library items | `VoiceLibrary` |
+| In-grid sound rename | Double-click rename for placed sounds | `DroppableCell`, `PlacedSoundItem` |
+| Voice visibility filter | Hides note numbers from filtered performance without deleting raw data | `VoiceLibrary`, `performanceSelectors.ts` |
+| Destructive note deletion | Permanently removes all events for a note number from the active performance | `VoiceLibrary` -> `handleDestructiveDelete` |
+| Reachability visualization | Shows left/right finger reach maps for a chosen pad | `LayoutDesigner` context menu |
+| Finger constraint locks | Locks a pad to `L1-L5` or `R1-R5` style constraints | `LayoutDesigner` context menu |
+| Layout duplication | Clones the active mapping as another variant | Workbench settings "Duplicate Layout" |
+| Mapping metadata | Keeps `name`, `notes`, `layoutMode`, `version`, and `savedAt` on mappings | `GridMapping`, Workbench logic |
+| Mapping score cache | Caches score on mappings for later reference | `GridMapping.scoreCache` |
+| Advanced solver selection | Exposes beam vs genetic analysis in advanced mode | Workbench advanced toggle |
+| Solver result switching | Lets user switch which stored solver result is visualized | Workbench advanced mode |
+| Model comparison tab | Compares beam and genetic results | `AnalysisPanel` comparison tab |
+| Optimization process tab | Visualizes annealing process and stats | `AnalysisPanel` optimization tab |
+| Event log reassignment | Allows manual per-event hand/finger override from event log table | `EventLogTable`, Event Analysis page |
+| Practice loop controls | Steps between event N and N+1 at fixed speeds | `PracticeLoopControls`, `usePracticeLoop` |
+| Event-analysis exports | Exports full metrics, hard transitions, and loop settings as JSON | `eventExport.ts` |
+| Timeline zoom | Scales horizontal timeline density | `TimelinePage` |
+| Song status badges | Shows "In Progress" or "Mastered" heuristics on cards | `SongCard` |
+
+## Debug / Developer Tools
+
+| Feature | Current behavior | Primary entry points |
+|---|---|---|
+| Dev-only Cost Debug route | Detailed per-event and annealing diagnostic view | `/cost-debug` in development only |
+| Event cost sorting | Sorts debug events by time or highest cost | `CostDebugPage` |
+| Annealing trajectory view | Visualizes optimization steps and temperature acceptance | `CostDebugPage` |
+| Annealing metrics view | Exposes annealing aggregate telemetry | `CostDebugPage` |
+| Debug event model | Per-event cost breakdown, pad, finger, difficulty, and event key | `EngineDebugEvent` |
+| Annealing trace model | Full iteration trace with component shares | `AnnealingIterationSnapshot` |
+| Extensive fixture/test corpus | Encodes solver behavior expectations and mapping coverage cases | `src/engine/__tests__` |
+| Seeded RNG for deterministic optimization | Supports reproducible mutation paths | `seededRng.ts`, annealing solver |
+| Built-in default test MIDI | Gives developers and testers an always-available starting song | `src/data/testData.ts` |
+
+## Experimental Features
+
+| Feature | Why it is experimental or weakly integrated | Evidence |
+|---|---|---|
+| Genetic solver as user-facing workflow | Available only behind advanced controls and mainly used for comparison | Workbench advanced mode, `GeneticSolver` |
+| `sectionMaps` | Present in the data model but not meaningfully surfaced in current UI | `ProjectState`, `SectionMap` |
+| Multiple instrument configs | `instrumentConfigs[]` exists, but the UI behaves as single-config | `ProjectState`, import logic |
+| Layout templates | `LayoutTemplate` and `STANDARD_KIT_TEMPLATE` exist but are not surfaced in the active workflow | `src/types/layout.ts` |
+| Practice loop as playback tool | Current implementation only steps event selection; no real audio/MIDI playback | `usePracticeLoop.ts` |
+| Timeline transport | Timeline has `currentTime` and `isPlaying` props but no active playback engine | `TimelinePage`, `Timeline` |
+| Legacy default hand-pose model in note space | Coexists with newer Pose 0 pad-space model | `handPose.ts`, `naturalHandPose.ts` |
+| Deprecated `setEngineResult` compatibility stub | Maintained only to avoid breaking older consumers | `ProjectContext.tsx` |
+
+## Feature Boundaries To Carry Forward
+
+- Import does not auto-place sounds.
+- Optimization is valid only with full note coverage.
+- Event analysis is derived from solver debug output, not raw MIDI alone.
+- The workbench is the operational center; alternate routes are drill-down views, not independent editing systems.

--- a/PRODUCT_MODEL.md
+++ b/PRODUCT_MODEL.md
@@ -1,0 +1,153 @@
+# Product Model
+
+## Product Purpose
+
+The repository implements a local-first desktop-style web app for turning a MIDI performance into a playable Ableton Push drum-pad layout. The product combines three responsibilities:
+
+1. Import and persist song-specific performance material.
+2. Author or generate an 8x8 pad mapping for the required notes.
+3. Evaluate that mapping with a biomechanical solver and expose the result through summary, timeline, and event-level analysis views.
+
+This is not a generic DAW companion or a generic MIDI viewer. The product is specifically built around Push-style grid performance ergonomics.
+
+## Primary User
+
+Primary user:
+
+- A Push performer, finger drummer, or electronic musician who wants a MIDI-driven pad layout that is physically playable for their hands.
+
+Secondary users:
+
+- A power user comparing solver outputs and layout strategies.
+- A developer or researcher inspecting cost breakdowns and transition behavior through debug tooling.
+
+## Core Job To Be Done
+
+When I have a MIDI performance I want to play on an 8x8 Push grid, I want to place or optimize the required notes onto pads in a way that fits my hands and movement limits so I can perform the piece with less strain and fewer awkward transitions.
+
+Supporting jobs:
+
+- Understand why a mapping is difficult.
+- Personalize the solver with my natural resting hand pose.
+- Save work per song and return later.
+- Export project state or analysis artifacts when needed.
+
+## Product Boundary
+
+The current product covers:
+
+- Song portfolio management in local storage.
+- MIDI linking/import into a song-specific project state.
+- Layout authoring on a fixed 8x8 `drum_64` grid.
+- Pose-aware deterministic seeding and solver-aware optimization.
+- Solver result inspection across multiple analysis surfaces.
+
+The current product does not fully cover:
+
+- Audio or MIDI playback.
+- Cloud sync or multi-user collaboration.
+- A live section-based workflow, despite dormant `sectionMaps`.
+- Multiple instrument modes beyond `drum_64`.
+
+## Major Workflows
+
+| Workflow | User intent | Main outcome |
+|---|---|---|
+| Create/select song | Choose a container for work | Active song in dashboard |
+| Link MIDI to song | Bring in playable source material | `Song` metadata plus persisted `ProjectState` |
+| Open workbench | Hydrate song state into editing context | Active layout, mapping, voices, pose, solver state |
+| Configure Pose 0 | Personalize neutral hand positions | Updated `naturalHandPoses[0]` |
+| Build mapping | Place notes on pads manually or with helpers | Updated `GridMapping` |
+| Run analysis | Score current mapping without changing layout | Stored `EngineResult` in `solverResults` |
+| Optimize layout | Improve mapping ergonomically | Overwritten or updated mapping plus annealing result |
+| Inspect chronology | Review event order and finger labels | Timeline understanding |
+| Inspect transitions | Review event-to-event difficulty | Analyzed events, transitions, onion-skin model |
+| Persist/export | Save or move data out of app | Song-local autosave, project JSON, event-analysis JSON |
+
+## Core Domain Objects
+
+| Object | Role in product |
+|---|---|
+| `Song` | Portfolio entry and entry point into a project |
+| `ProjectState` | Canonical project-level source of truth |
+| `LayoutSnapshot` | Imported performance context stored inside project state |
+| `Performance` | Sorted list of musical note events to be analyzed |
+| `NoteEvent` | Individual timed note trigger from MIDI |
+| `InstrumentConfig` | Defines the 8x8 window and bottom-left note |
+| `Voice` | Unique note identity exposed to the user as a draggable sound |
+| `GridMapping` | Pad-to-voice assignment model being authored and optimized |
+| `NaturalHandPose` | User-specific neutral finger placement model |
+| `EngineConfiguration` | Solver tuning and resting-pose settings |
+| `EngineResult` | Stored solver output for a mapping/performance pair |
+| `EngineDebugEvent` | Per-event assignment and cost detail |
+| `AnalyzedEvent` | Grouped polyphonic moment derived from debug events |
+| `Transition` | Derived movement analysis between consecutive analyzed events |
+
+## Product Rules, Constraints, and Invariants
+
+### Structural constraints
+
+- The pad surface is always 8 columns by 8 rows.
+- The active performance must be sorted by `startTime`.
+- Row indexing is fixed: row `0` is bottom, row `7` is top.
+- Pad identifiers are encoded as `"row,col"`.
+- Only `drum_64` instrument mode is currently active in product behavior.
+
+### Workflow constraints
+
+- MIDI import creates an explicit empty grid; voices start in staging, not pre-placed.
+- Optimization requires full note coverage in the current mapping.
+- Pose-driven flows assume `naturalHandPoses[0]` exists and is valid.
+- Cross-route analysis should follow `activeMappingId` and `activeLayoutId`.
+- Manual finger overrides should be keyed by stable `eventKey` when present.
+
+### Persistence constraints
+
+- Songs are stored in `push_perf_songs`.
+- Project states are stored in `push_perf_project_<projectStateId>`.
+- Theme is stored in `push_perf_theme`.
+- Workbench auto-saves a hydrated song state after a debounce.
+
+## State Model
+
+Primary source of truth:
+
+- `ProjectContext.projectState`
+
+Durable supporting state:
+
+- `SongService` song catalog
+- per-song persisted `ProjectState`
+
+Derived state:
+
+- `engineResult` from `solverResults[activeSolverId]`
+- filtered active performance from `ignoredNoteNumbers`
+- analyzed event/transition/onion-skin models
+
+Transient view state:
+
+- selected tabs, zoom, selected event index, edit mode, menus, drag state, solver progress
+
+## Terminology Glossary
+
+| Term | Canonical meaning in this product |
+|---|---|
+| Song | The portfolio-level container the user selects on the dashboard |
+| Project | The persisted working state attached to a song |
+| Performance | Time-sorted musical data derived from MIDI |
+| Note Event | One timed note occurrence in a performance |
+| Voice | A unique note identity that can be assigned to a pad |
+| Cell | The MIDI note slot identity behind a voice; often expressed as the note number |
+| Pad | A physical grid position on the 8x8 layout |
+| Mapping | The current pad-to-voice assignment model |
+| Layout | User-facing synonym for the current mapping configuration; in code this also appears in `LayoutSnapshot`, so the term is overloaded |
+| Pose 0 | The default personalized natural hand pose at `naturalHandPoses[0]` |
+| Manual Assignment | A user override of solver-selected hand/finger for a specific event |
+| Solver Result | Stored ergonomic analysis output for a solver run |
+| Event Analysis | Derived view that groups notes into moments and transitions |
+| Timeline | Chronological lane view of the mapped performance |
+
+## Canonical Product Statement
+
+The true product model is: a song-scoped Push layout workstation that imports MIDI into a project, lets the user author or generate a pad mapping, personalizes that mapping with a natural hand pose, and evaluates the mapping through a biomechanical analysis pipeline.

--- a/SCREEN_ARCHITECTURE.md
+++ b/SCREEN_ARCHITECTURE.md
@@ -1,0 +1,355 @@
+# Screen Architecture
+
+## Route Inventory
+
+| Route | Screen | Primary responsibility |
+|---|---|---|
+| `/` | Dashboard | Song portfolio, MIDI linking, and navigation into editing/analysis |
+| `/workbench` | Workbench | Main layout authoring, pose editing, solver orchestration, and summary analysis |
+| `/timeline` | Timeline | Chronological inspection of mapped voices and finger labels |
+| `/event-analysis` | Event Analysis | Deep event-by-event and transition inspection |
+| `/cost-debug` | Cost Debug | Developer-only diagnostic surface for cost internals |
+
+## Navigation Model
+
+```mermaid
+flowchart LR
+  dashboard["Dashboard /"] --> workbench["Workbench /workbench?songId=..."]
+  dashboard --> eventAnalysis["Event Analysis /event-analysis?songId=..."]
+  workbench --> timeline["Timeline /timeline?songId=..."]
+  workbench --> eventAnalysis
+  workbench --> costDebug["Cost Debug /cost-debug?songId=..."]
+  timeline --> workbench
+  eventAnalysis --> workbench
+  costDebug --> workbench
+```
+
+## Dashboard
+
+Purpose:
+
+- Portfolio-level home screen.
+- Entry point for selecting, creating, linking, and deleting songs.
+
+Key panels/components:
+
+- Header bar with product title and placeholder account/settings icons.
+- Song grid of `SongCard` components.
+- "Add New Song" card.
+
+Primary user actions:
+
+- Add song.
+- Edit song title and BPM.
+- Delete song.
+- Link or re-link MIDI.
+- Open workbench.
+- Open event analysis directly.
+
+Data dependencies:
+
+- `SongService.getAllSongs()`
+- `SongService.hasMidiData(songId)`
+- default test-song seeding
+
+## Workbench
+
+Purpose:
+
+- Operational core of the application.
+- Combines editing, personalization, analysis, optimization, and persistence in one workspace.
+
+High-level layout:
+
+- Top global header
+- Middle toolbar
+- Main body with:
+  - left work surface inside `LayoutDesigner`
+  - center grid editor inside `LayoutDesigner`
+  - right `AnalysisPanel`
+
+### Workbench Header
+
+Purpose:
+
+- Establishes song context and app-level actions.
+
+Key panels/components:
+
+- Product title and subtitle.
+- Current song auto-save pill.
+- Route links to Dashboard, Timeline, Event Analysis, and Cost Debug.
+- Settings menu.
+- Theme toggle.
+- Undo/redo and project save/load controls.
+
+Primary user actions:
+
+- Navigate to other screens.
+- Toggle display options and layout options.
+- Toggle theme.
+- Undo/redo.
+- Save/load project JSON.
+
+Data dependencies:
+
+- `songId`, `songName`
+- `canUndo`, `canRedo`
+- `projectState`
+- theme state
+
+### Workbench Toolbar
+
+Purpose:
+
+- Exposes the main authoring and solver actions for the active mapping.
+
+Key panels/components:
+
+- Clear Grid
+- Seed
+- Natural
+- Auto-Arrange
+- Random
+- Run Analysis
+- Advanced solver controls
+
+Primary user actions:
+
+- Clear mapping.
+- Generate a starting mapping.
+- Optimize a mapping.
+- Run or compare solver outputs.
+
+Data dependencies:
+
+- active mapping
+- filtered performance
+- Pose 0 validity
+- current solver results
+
+### LayoutDesigner: Left Panel
+
+Purpose:
+
+- Handles source-material management and pose editing.
+
+Key panels/components:
+
+- Tab strip: Library | Pose
+- `VoiceLibrary`
+- `NaturalHandPosePanel`
+
+Primary user actions:
+
+- Select, rename, recolor, hide, or delete voices.
+- Edit Pose 0.
+- Toggle pose edit mode and choose active finger tools.
+
+Data dependencies:
+
+- `parkedSounds`
+- `activeMapping`
+- `projectState.ignoredNoteNumbers`
+- `projectState.naturalHandPoses`
+- raw and filtered performance
+
+### LayoutDesigner: Center Grid
+
+Purpose:
+
+- Physical mapping canvas for the 8x8 pad layout.
+
+Key panels/components:
+
+- 8x8 `DroppableCell` matrix
+- layout mode indicator
+- context menu
+- reachability overlay
+- pose ghost markers
+- `FingerLegend`
+
+Primary user actions:
+
+- Drag/drop assign, move, swap, or unassign sounds.
+- Double-click rename placed sounds.
+- Right-click for finger locks, reachability, and remove actions.
+- Click pads during pose edit mode to assign fingers.
+
+Data dependencies:
+
+- `GridMapping.cells`
+- `fingerConstraints`
+- `engineResult`
+- manual assignments
+- pose ghost markers
+- instrument config for note labeling
+
+### AnalysisPanel: Right Panel
+
+Purpose:
+
+- Summarizes the currently selected solver output without leaving the workbench.
+
+Key panels/components:
+
+- Tab strip: Performance Summary | Model Comparison | Optimization Process
+- ergonomic score cards
+- hand-balance bar
+- average metric list
+- `SoundAssignmentTable`
+- solver comparison table
+- evolution and annealing graphs
+
+Primary user actions:
+
+- Inspect summary metrics.
+- Compare solver outputs.
+- Review optimization progress.
+
+Data dependencies:
+
+- `engineResult`
+- `activeMapping`
+- filtered `Performance`
+- stored solver results from context
+
+## Timeline
+
+Purpose:
+
+- Shows the mapped performance as a time-based lane chart for review rather than editing.
+
+Key panels/components:
+
+- Header with back link, song pill, and zoom slider.
+- Ruler.
+- Left lane header for voices.
+- Scrollable note lanes.
+- now-bar / seek indicator.
+
+Primary user actions:
+
+- Adjust zoom.
+- Click to seek.
+- Visually inspect which voices occur when and which finger label was assigned.
+
+Data dependencies:
+
+- hydrated song state
+- active layout
+- active mapping
+- derived `voices`
+- `engineResult.debugEvents` for finger labels
+
+## Event Analysis
+
+Purpose:
+
+- Deep-dive inspection surface for moments, transitions, and manual event overrides.
+
+High-level layout:
+
+- Header
+- Export bar
+- Three-column body
+
+### Left Column
+
+Purpose:
+
+- Event navigation and event-level editing entry point.
+
+Key panels/components:
+
+- tab strip: Timeline | Event Log
+- `EventTimelinePanel`
+- `EventLogTable`
+
+Primary user actions:
+
+- Select the focused transition.
+- Use arrow keys to move across events.
+- Change hand/finger overrides from the event log.
+
+Data dependencies:
+
+- `AnalyzedEvent[]`
+- `Transition[]`
+- `engineResult.debugEvents`
+
+### Center Column
+
+Purpose:
+
+- Spatial visualization of current/previous/next event relationships.
+
+Key panels/components:
+
+- `OnionSkinGrid`
+
+Primary user actions:
+
+- Inspect current pads, next pads, shared pads, and movement vectors.
+
+Data dependencies:
+
+- `OnionSkinModel`
+
+### Right Column
+
+Purpose:
+
+- Focused transition metrics and practice-loop controls.
+
+Key panels/components:
+
+- `PracticeLoopControls`
+- `TransitionMetricsPanel`
+
+Primary user actions:
+
+- Start/stop visual practice loop.
+- Inspect distance, speed, stretch, hand switch, and finger change.
+
+Data dependencies:
+
+- selected event index
+- current analyzed event
+- current transition
+
+## Cost Debug
+
+Purpose:
+
+- Developer-only diagnostic screen for solver internals and annealing telemetry.
+
+Key panels/components:
+
+- Header with route links.
+- Mode toggle:
+  - Event Costs
+  - Annealing Trajectory
+  - Annealing Metrics
+
+Primary user actions:
+
+- Sort by time or cost.
+- Inspect per-event cost breakdowns.
+- Inspect annealing trajectory and acceptance behavior.
+
+Data dependencies:
+
+- `engineResult.debugEvents`
+- `engineResult.annealingTrace`
+- song name from `SongService`
+
+## Screen Responsibility Summary
+
+| Screen | Owns editing? | Owns solver execution? | Owns deep analysis? |
+|---|---|---|---|
+| Dashboard | No | No | No |
+| Workbench | Yes | Yes | Summary only |
+| Timeline | No | No | Chronological inspection only |
+| Event Analysis | Limited manual overrides only | No | Yes |
+| Cost Debug | No | No | Developer-only internals |

--- a/TASK_FLOWS.md
+++ b/TASK_FLOWS.md
@@ -1,0 +1,327 @@
+# Task Flows
+
+## Flow 1: Create or Select a Song
+
+Entry point: Dashboard `/`
+
+Steps:
+
+1. The user opens the dashboard and sees the song portfolio.
+2. The user either selects an existing song card or creates a new one with "Add New Song".
+3. The selected song becomes the container for future MIDI linking, editing, and analysis.
+
+UI screens used:
+
+- Dashboard
+- SongCard
+
+Engine interactions:
+
+- None. This flow touches `SongService` and local storage, not the solver.
+
+State changes:
+
+- Creates or reads a `Song`.
+
+## Flow 2: Link MIDI to a Song
+
+Entry point: Dashboard song card "Link MIDI" or "Re-link"
+
+Steps:
+
+1. The user opens the file picker from a song card.
+2. The app reads the MIDI file and parses note events, voices, tempo, and note range.
+3. The app derives a new `ProjectState` for the song.
+4. The app persists both song metadata and the generated project state.
+
+UI screens used:
+
+- Dashboard
+- SongCard
+
+Engine interactions:
+
+- No solver execution yet.
+- Uses the import pipeline:
+  - `parseMidiFileToProject`
+  - `GridMapService.noteToGrid`
+  - `SongService.createProjectStateFromMidi`
+
+State changes:
+
+- Updates `Song.midiData`, `midiFileName`, BPM, duration, key.
+- Creates `LayoutSnapshot`, `Performance`, `Voice[]`, `InstrumentConfig`, empty `GridMapping`, default Pose 0.
+
+## Flow 3: Open and Hydrate the Workbench
+
+Entry point: Dashboard "Editor" button or direct route `/workbench?songId=<id>`
+
+Steps:
+
+1. The route reads `songId`.
+2. `useSongStateHydration` checks whether the current context already matches that song.
+3. The persisted project state is loaded from local storage if needed.
+4. The workbench resolves the active layout and active mapping.
+5. Auto-save is armed for further edits.
+
+UI screens used:
+
+- Workbench
+
+Engine interactions:
+
+- None required on entry.
+- Future analysis depends on stored `solverResults` or user-triggered runs.
+
+State changes:
+
+- Hydrates `ProjectContext.projectState`.
+- Sets `activeMappingId` if missing.
+
+## Flow 4: Configure Natural Hand Pose
+
+Entry point: Workbench left panel, "Pose" tab
+
+Steps:
+
+1. The user switches from "Library" to "Pose".
+2. The user enters pose edit mode.
+3. The user selects a finger tool and assigns pads on the grid.
+4. The user optionally adjusts preview offset and clears individual or all fingers.
+5. The pose is normalized and stored back into `naturalHandPoses[0]`.
+
+UI screens used:
+
+- Workbench
+- LayoutDesigner
+- NaturalHandPosePanel
+
+Engine interactions:
+
+- No direct solver run is required.
+- The pose later influences:
+  - neutral pad overrides for solvers
+  - pose-based seeding
+  - natural assignment order
+
+State changes:
+
+- Updates `ProjectState.naturalHandPoses[0]`.
+
+## Flow 5: Build a Mapping Manually
+
+Entry point: Workbench with imported song state
+
+Steps:
+
+1. The user views unassigned voices in the library.
+2. The user drags voices onto grid pads.
+3. The user can move, swap, or unassign placed voices.
+4. The user can rename voices, hide notes, or remove notes from the raw performance.
+5. The mapping is updated with `layoutMode: 'manual'`.
+
+UI screens used:
+
+- Workbench
+- VoiceLibrary
+- LayoutDesigner
+
+Engine interactions:
+
+- No required engine call during drag-and-drop.
+- Later analysis reads the resulting `GridMapping`.
+
+State changes:
+
+- Updates `GridMapping.cells`
+- Updates `fingerConstraints` if locks move with sounds
+- May update `parkedSounds`, `ignoredNoteNumbers`, or raw performance events
+
+## Flow 6: Generate a Starting Mapping Automatically
+
+Entry point: Workbench toolbar or settings menu
+
+Variants:
+
+1. `Seed`
+   - Full deterministic coverage from Pose 0 anchors and note importance.
+2. `Natural`
+   - Places only unassigned voices, prioritizing Pose 0 pads first.
+3. `Random`
+   - Places unassigned voices onto empty pads randomly.
+4. `Organize by 4x4 Banks`
+   - Places sounds using Push-style quadrant logic.
+
+UI screens used:
+
+- Workbench
+- LayoutDesigner
+
+Engine interactions:
+
+- `seedMappingFromPose0`
+- `getPose0PadsWithOffset`
+- `mapToQuadrants`
+
+State changes:
+
+- Creates or updates the active `GridMapping`
+- Sets `layoutMode` to `optimized`, `manual`, `random`, or `auto` depending on path
+
+## Flow 7: Run Analysis on the Current Mapping
+
+Entry point: Workbench "Run Analysis"
+
+Steps:
+
+1. The user triggers analysis from the toolbar.
+2. The workbench resolves the filtered active performance and the active mapping.
+3. The selected solver runs, defaulting to beam unless advanced mode chooses genetic.
+4. The result is stored in `solverResults` and may become `activeSolverId`.
+5. The right analysis panel reflects the updated result.
+
+UI screens used:
+
+- Workbench
+- AnalysisPanel
+
+Engine interactions:
+
+- `BiomechanicalSolver`
+- `BeamSolver` or `GeneticSolver`
+- optional neutral-pad override from Pose 0
+- manual assignments passed into solver if present
+
+State changes:
+
+- Updates `ProjectState.solverResults`
+- Updates `activeSolverId`
+
+## Flow 8: Optimize the Layout
+
+Entry point: Workbench "Auto-Arrange"
+
+Steps:
+
+1. The user clicks "Auto-Arrange".
+2. The workbench checks that the active mapping exists and covers every note in the filtered performance.
+3. The annealing solver mutates mappings and scores them with a fast beam evaluation loop.
+4. The best mapping replaces the current mapping.
+5. The annealing result is stored and can be viewed in analysis.
+
+UI screens used:
+
+- Workbench
+- AnalysisPanel optimization tab
+
+Engine interactions:
+
+- `computeMappingCoverage`
+- `AnnealingSolver`
+- `BeamSolver` as layout evaluator
+
+State changes:
+
+- Rewrites the active `GridMapping`
+- Updates mapping metadata such as `layoutMode`, `scoreCache`, `version`, `savedAt`
+- Stores `solverResults['annealing']`
+
+## Flow 9: Inspect the Chronological Result
+
+Entry point: Workbench "Timeline View" or direct route `/timeline?songId=<id>`
+
+Steps:
+
+1. The route hydrates the song state.
+2. The page resolves the active layout and active mapping.
+3. Voices are converted into timeline lanes.
+4. Finger labels are derived from the current engine result and displayed on note blocks.
+5. The user scrubs or zooms the timeline for inspection.
+
+UI screens used:
+
+- Timeline page
+- Timeline component
+
+Engine interactions:
+
+- No new solve.
+- Reads `engineResult.debugEvents` to derive finger labels.
+
+State changes:
+
+- No domain-state mutation.
+- Uses local UI state for `currentTime` and `zoom`.
+
+## Flow 10: Deep-Dive Event and Transition Analysis
+
+Entry point: Dashboard "Analyze", Workbench "Event Analysis", or direct route `/event-analysis?songId=<id>`
+
+Steps:
+
+1. The route hydrates the song state.
+2. The page reads the active engine result and filtered performance.
+3. Debug events are grouped into analyzed events.
+4. Consecutive transitions are computed.
+5. The onion-skin model is built for the selected event.
+6. The user navigates via the timeline or event log.
+7. The user can override hand/finger assignments for specific events.
+8. The user can inspect practice-loop controls and export analysis JSON.
+
+UI screens used:
+
+- Event Analysis page
+- EventTimelinePanel
+- EventLogTable
+- OnionSkinGrid
+- TransitionMetricsPanel
+- PracticeLoopControls
+
+Engine interactions:
+
+- `analyzeEvents`
+- `analyzeAllTransitions`
+- `buildOnionSkinModel`
+
+State changes:
+
+- Optional updates to `manualAssignments`
+- Local UI state for selected event, left tab, and practice loop
+
+## Flow 11: Save, Load, and Export
+
+Entry point: Workbench header and Event Analysis export bar
+
+Steps:
+
+1. The user exports the current project as JSON, or loads a previously exported project file.
+2. The loader validates the incoming project shape before replacing current state.
+3. The user optionally exports event-analysis artifacts as separate JSON files.
+
+UI screens used:
+
+- Workbench
+- Event Analysis page
+
+Engine interactions:
+
+- No solver required.
+
+State changes:
+
+- `saveProject` serializes current `ProjectState`
+- `loadProject` may replace current `ProjectState`
+- event-export paths produce files only
+
+## Actual Recommended Flow Implied by Current Code
+
+The codebase implicitly recommends this path:
+
+1. Pick or create a song.
+2. Link MIDI.
+3. Open the workbench.
+4. Define Pose 0 if personalization matters.
+5. Use `Seed` or `Natural` to reach full mapping coverage.
+6. Run analysis.
+7. Use `Auto-Arrange` once a valid starting mapping exists.
+8. Inspect timeline and event analysis for validation.

--- a/UI_COMPONENT_MODEL.md
+++ b/UI_COMPONENT_MODEL.md
@@ -1,0 +1,145 @@
+# UI Component Model
+
+## App Shell
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `ThemeProvider` | Global theme state and root class management | `push_perf_theme` local storage | theme toggle |
+| `ProjectProvider` | Makes `ProjectState`, history, and solver APIs available | initial project defaults | project updates, undo/redo, solver runs, optimization |
+| `Routes` in `main.tsx` | Maps URLs to product surfaces | route path and query params | page-level screen mounting |
+
+## Dashboard Surface
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `Dashboard` | Portfolio shell and song list | `SongService.getAllSongs()`, MIDI-linked status | create song, delete song, link MIDI, open editor/analyze |
+| `SongCard` | Per-song summary and actions | `SongMetadata`, `hasMidiLinked` | rename song, edit BPM, delete, link/re-link MIDI, navigate to workbench/event analysis |
+
+Logical hierarchy:
+
+```text
+Dashboard
+  Header
+  Song Grid
+    SongCard
+  Add Song Card
+```
+
+## Workbench Surface
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `Workbench` | Main orchestrator for hydration, autosave, layout actions, navigation, and analysis controls | `ProjectContext`, `songId`, `useSongStateHydration` | save/load, undo/redo, route navigation, analysis run, optimization, layout helper actions |
+| `Button` | Shared action primitive | variant/size/loading state | user action handlers |
+| `ThemeToggle` | Theme mode switch | `ThemeContext` | toggles theme |
+| `AnalysisPanel` | Inline summary/comparison/optimization analysis | `engineResult`, `activeMapping`, `performance`, stored solver results | tab switching only |
+
+Logical hierarchy:
+
+```text
+Workbench
+  Header
+  Action Toolbar
+  LayoutDesigner
+  AnalysisPanel
+```
+
+## LayoutDesigner Subtree
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `LayoutDesigner` | Three-part editor shell handling drag/drop, selection, context menu, voice visibility, and pose edit mode | `parkedSounds`, `activeMapping`, `instrumentConfig`, `projectState`, `engineResult` | assign/move/remove sounds, update project state, toggle library/pose mode |
+| `VoiceLibrary` | Manages unassigned, placed, and detected voice lists | `parkedSounds`, `activeMapping`, raw active performance, ignored notes | select/edit/delete voices, toggle visibility, destructive delete, clear staging |
+| `DraggableSound` | Draggable library item with inline edit controls | `Voice`, visibility state | drag, edit, delete, visibility toggle |
+| `PlacedSoundItem` | List item for already placed voices | placed `Voice`, cell key | select and rename |
+| `NaturalHandPosePanel` | Pose editing control surface | `pose0`, active finger, preview offset, edit mode | select finger, clear assignments, save/normalize pose, toggle edit mode |
+| `DroppableCell` | One grid pad with assignment, label, heatmap, lock, and pose marker layers | assigned sound, finger assignment map, finger constraint, pose ghost marker | click, double-click rename, drag/drop, context menu |
+| `FingerLegend` | Visual legend for left/right finger color mapping | theme CSS variables | none |
+
+Logical hierarchy:
+
+```text
+LayoutDesigner
+  Left Panel
+    VoiceLibrary
+      DraggableSound
+      PlacedSoundItem
+    NaturalHandPosePanel
+  Center Grid
+    8x8 DroppableCell matrix
+    FingerLegend
+  Floating Context Menu
+```
+
+## AnalysisPanel Subtree
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `AnalysisPanel` | Hosts tabs for summary, solver comparison, and optimization process | current and stored solver results, active mapping, performance | switches internal tab |
+| `SoundAssignmentTable` | Summarizes placed sounds, pads, and most common assigned finger | `activeMapping`, `engineResult` | optional sound rename |
+| `EvolutionGraph` | Visualizes genetic-algorithm convergence | `geneticResult.evolutionLog`, beam reference cost | none |
+| `AnnealingProcessGraph` | Visualizes annealing temperature and cost over time | `annealingResult.optimizationLog` | none |
+
+## Timeline Surface
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `TimelinePage` | Route shell for timeline hydration and voice/finger derivation | `ProjectContext`, `songId`, `engineResult`, active mapping | zoom changes, back navigation, seek |
+| `Timeline` | Lane-based visualization of mapped voices over time | `Performance`, `Voice[]`, `fingerAssignments`, `currentTime`, `zoom` | seek on click |
+
+Logical hierarchy:
+
+```text
+TimelinePage
+  Header
+  Timeline
+    Ruler
+    Voice Lane Labels
+    Note Blocks
+    Now Bar
+```
+
+## Event Analysis Surface
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `EventAnalysisPage` | Route shell for hydration, difficulty summary, and manual assignment writes | `ProjectContext`, `songId`, filtered performance, `engineResult` | navigation and assignment override callback |
+| `EventAnalysisPanel` | Builds analyzed events, transitions, onion-skin model, and export actions | `engineResult`, `performance` | left-tab changes, event selection, export clicks, practice loop |
+| `EventTimelinePanel` | Selectable transition list with difficulty bars | `AnalyzedEvent[]`, `Transition[]`, selected index | select focused transition |
+| `EventLogTable` | Sorted event table with per-event hand/finger overrides | `EngineDebugEvent[]` | writes `manualAssignments` |
+| `OnionSkinGrid` | Spatial visualization of current/next/previous event states and movement vectors | `OnionSkinModel` | optional hover callbacks |
+| `TransitionMetricsPanel` | Shows metrics for the selected transition | current analyzed event, current transition | none |
+| `PracticeLoopControls` | Controls the visual practice loop for a selected transition | selected event index, playback state | start/stop practice loop |
+
+Logical hierarchy:
+
+```text
+EventAnalysisPage
+  Header
+  EventAnalysisPanel
+    Export Bar
+    Left Column
+      EventTimelinePanel or EventLogTable
+    Center Column
+      OnionSkinGrid
+    Right Column
+      PracticeLoopControls
+      TransitionMetricsPanel
+```
+
+## Cost Debug Surface
+
+| Component | Responsibility | Consumes | Triggers |
+|---|---|---|---|
+| `CostDebugPage` | Developer-facing diagnostic route for event costs and annealing telemetry | `engineResult`, `songId` | mode switch, sort selection, event selection |
+| `EventCostsView` | Displays sortable event-level cost breakdowns | `debugEvents` | selects event, changes sort mode |
+| `AnnealingTrajectoryView` | Shows annealing time-series behavior | `annealingTrace` | none |
+| `AnnealingMetricsView` | Shows annealing aggregate metrics | `annealingTrace` | none |
+
+## Component Boundaries That Matter For Redesign
+
+- `Workbench` is not just a page wrapper; it is the coordination boundary for persistence, solver actions, and navigation.
+- `LayoutDesigner` owns most interaction complexity for the main authoring flow.
+- `AnalysisPanel` is a summary surface, while `EventAnalysisPanel` is the detailed diagnostic surface.
+- `EventAnalysisPanel` depends on derived models; it does not own raw project state beyond emitting manual assignment overrides.
+- `Timeline` is read-only and depends on already-selected mapping plus already-computed solver output.

--- a/WIREFRAME_SPEC.md
+++ b/WIREFRAME_SPEC.md
@@ -1,0 +1,256 @@
+# Wireframe Spec
+
+## Scope
+
+This spec describes structure only. It does not prescribe visual style, branding, or motion. Each screen description is grounded in the current repository behavior and should be treated as a layout-zone contract for future wireframing.
+
+## Dashboard
+
+Primary goal:
+
+- Let the user manage songs and launch into editing or analysis.
+
+### Layout zones
+
+Zone A: Global header
+
+- Product title
+- short subtitle explaining the portfolio purpose
+- utility icons or future account/settings placeholders
+
+Zone B: Song portfolio grid
+
+- repeating song cards
+- each card should surface:
+  - song title
+  - BPM
+  - MIDI-linked status
+  - quick status badge
+  - primary actions: Editor, Analyze
+  - secondary actions: Link/Re-link MIDI, delete, rename
+
+Zone C: Add-song card
+
+- visually distinct from existing songs
+- clear affordance for creating a new song container
+
+Zone D: Optional footer utility strip
+
+- currently empty in behavior
+- can remain reserved for future global actions, but should not compete with the song grid
+
+### Information hierarchy
+
+1. Song identity and MIDI readiness
+2. Primary next actions: open workbench or open analysis
+3. Secondary metadata and maintenance actions
+
+### Interaction notes
+
+- The user should understand whether a song has MIDI linked before opening other screens.
+- The card should make editing vs analysis feel like distinct destinations.
+
+## Workbench
+
+Primary goal:
+
+- Let the user build, personalize, analyze, and optimize a mapping.
+
+### Layout zones
+
+Zone A: Global workspace header
+
+- product title and workspace subtitle
+- current song pill with autosave status
+- route links to Dashboard, Timeline, Event Analysis, and Cost Debug
+- theme toggle
+- undo/redo
+- save/load project controls
+- settings menu for view and layout utilities
+
+Zone B: Action toolbar
+
+- clear grid
+- Seed
+- Natural
+- Auto-Arrange
+- Random
+- Run Analysis
+- advanced solver controls and result selector
+
+This zone should read as the decision strip for "what happens next to the mapping."
+
+Zone C: Left panel
+
+- tab strip: Library | Pose
+
+Library state:
+
+- list of unassigned voices
+- list of placed voices or detected notes as needed
+- per-voice controls: edit, hide, delete
+- destructive note deletion should be clearly separate from temporary hiding
+
+Pose state:
+
+- Pose 0 summary
+- edit mode toggle
+- finger palette
+- preview offset
+- clear/save actions
+
+Zone D: Center editor canvas
+
+- layout mode indicator
+- large 8x8 pad grid as the main focal surface
+- cells should support labels, heatmap overlays, lock indicators, and pose markers
+- context menu and reachability overlay anchored to the grid
+- finger legend under the grid
+
+Zone E: Right analysis panel
+
+- compact summary of current solver output
+- tabs:
+  - performance summary
+  - model comparison
+  - optimization process
+- sound assignment table in summary state
+
+### Information hierarchy
+
+1. Current song and current mapping state
+2. Primary mapping actions
+3. Left panel as source material / personalization
+4. Center grid as main authoring surface
+5. Right panel as "read the result" companion
+
+### Interaction notes
+
+- The toolbar should distinguish:
+  - authoring helpers that create coverage
+  - analysis actions that score the current state
+  - optimization actions that rewrite the mapping
+- The grid is the dominant surface and should not be visually crowded by secondary panels.
+
+## Event Analysis
+
+Primary goal:
+
+- Explain transition difficulty at the event level and allow manual event overrides.
+
+### Layout zones
+
+Zone A: Header
+
+- back link to workbench
+- page title
+- song/performance identifier
+- compact difficulty summary
+- links back to Dashboard and Workbench
+
+Zone B: Export bar
+
+- Export Metrics
+- Export Hard Transitions
+- Export Loop Settings
+
+Zone C: Left diagnostic column
+
+- tab strip: Timeline | Event Log
+
+Timeline state:
+
+- ordered list of event transitions
+- row shows:
+  - event indices
+  - timestamp
+  - time delta
+  - difficulty bar
+  - quick hand/finger indicators
+
+Event Log state:
+
+- sortable event table
+- per-event hand selector
+- per-event finger selector
+- cost column
+
+Zone D: Center visualization column
+
+- large onion-skin grid
+- should dominate the screen after the left navigation column
+- must communicate:
+  - current event pads
+  - next event pads
+  - shared pads
+  - movement vectors
+
+Zone E: Right metrics column
+
+- practice loop controls at the top
+- transition metrics card below
+- metrics include time delta, distance, speed pressure, stretch, composite score, and flags
+
+### Information hierarchy
+
+1. Which transition is selected
+2. Spatial movement context on the onion-skin grid
+3. Numeric explanation of difficulty
+4. Manual override controls and exports
+
+### Interaction notes
+
+- Event selection should feel like the master control for the whole page.
+- Event log reassignment is an editing action inside an otherwise diagnostic screen and should be visually separated from read-only metrics.
+
+## Timeline
+
+Primary goal:
+
+- Show the mapped performance as a chronological lane chart for fast pattern inspection.
+
+### Layout zones
+
+Zone A: Header
+
+- back link to workbench
+- page title
+- song identifier
+- zoom slider
+
+Zone B: Top ruler
+
+- time ticks in seconds
+- optional minor subdivisions when zoom allows
+
+Zone C: Left lane label strip
+
+- one row per mapped voice
+- voice color marker
+- voice name
+
+Zone D: Main timeline canvas
+
+- horizontal note blocks positioned by start time and duration
+- vertical grid lines
+- finger labels rendered on blocks when space permits
+- now-bar / seek indicator
+
+### Information hierarchy
+
+1. Voice identity by row
+2. Time position and clustering of notes
+3. Finger labels as an overlay
+
+### Interaction notes
+
+- This is an inspection screen, not a mapping editor.
+- Clicking the timeline should seek the cursor only; editing remains in the workbench.
+
+## Cross-Screen Wireframe Rules
+
+- Keep Dashboard focused on song selection and readiness.
+- Keep Workbench focused on authoring and summary feedback.
+- Keep Event Analysis focused on explanation and per-event override.
+- Keep Timeline focused on chronology and pattern readability.
+- Treat Cost Debug as a non-primary developer surface and exclude it from end-user wireframe priorities unless explicitly designing internal tools.


### PR DESCRIPTION
## Summary
- add eight repository-level product synthesis audit artifacts
- document the current product model, feature inventory, task flows, screen architecture, domain model, UI component model, design gaps, and wireframe spec
- ground the docs in the current routes, workbench/editor surfaces, state model, engine pipeline, and persistence behavior

## Testing
- not run (documentation-only audit)